### PR TITLE
Fix handle missing extra properties

### DIFF
--- a/src/js/features/data/makeGetDataRequest.js
+++ b/src/js/features/data/makeGetDataRequest.js
@@ -28,14 +28,14 @@ export const makeGetDataRequest = createAsyncThunk(
       // converting fields to usable form
       let fields = {
         ...queryParameterStack,
-        ...queryParameterStack.extra_properties,
+        ...(queryParameterStack.extra_properties ?? {}),
       };
-      delete fields.extra_properties;
+      if (fields.extra_properties) delete fields.extra_properties;
 
       fields = Object.entries(fields).map((item) => ({
         name: item[0],
         data: item[1],
-        isExtraProperty: queryParameterStack?.extra_properties.hasOwnProperty(
+        isExtraProperty: queryParameterStack.extra_properties?.hasOwnProperty(
           item[0]
         ),
       }));
@@ -47,8 +47,11 @@ export const makeGetDataRequest = createAsyncThunk(
       const individuals = overview.individuals;
 
       // unwinding extra properties to allChartsObj
-      const allChartsObj = { ...overview, ...overview.extra_properties };
-      delete allChartsObj.extra_properties;
+      const allChartsObj = {
+        ...overview,
+        ...(overview.extra_properties ?? {}),
+      };
+      if (allChartsObj.extra_properties) delete allChartsObj.extra_properties;
 
       // removing all non-chart keys
       Object.entries(allChartsObj).forEach(([key, value]) => {

--- a/src/js/features/data/makeGetDataRequest.js
+++ b/src/js/features/data/makeGetDataRequest.js
@@ -25,7 +25,7 @@ import { addQueryableFields } from '../query';
 const isChartConfig = (prop) => {
   if (typeof prop !== 'object') return false;
   return Object.values(prop).every((v) => typeof v === 'number');
-}
+};
 
 export const makeGetDataRequest = createAsyncThunk(
   'data/getConfigData',
@@ -37,13 +37,13 @@ export const makeGetDataRequest = createAsyncThunk(
       ]).then(([ov, f]) => [ov.data.overview, f.data]);
 
       // converting fields to usable form
-      let fields = {
-        ...queryParameterStack,
-        ...(queryParameterStack.extra_properties ?? {}),
+      const { extra_properties, ...everything_else } = queryParameterStack;
+      const fieldMap = {
+        ...everything_else,
+        ...extra_properties,
       };
-      if (fields.extra_properties) delete fields.extra_properties;
 
-      fields = Object.entries(fields).map((item) => ({
+      let fields = Object.entries(fieldMap).map((item) => ({
         name: item[0],
         data: item[1],
         isExtraProperty: queryParameterStack.extra_properties?.hasOwnProperty(
@@ -58,24 +58,23 @@ export const makeGetDataRequest = createAsyncThunk(
       const individuals = overview.individuals;
 
       // unwinding extra properties to allChartsObj
+      const { extra_properties_ovw, ...everything_else_ovw } = overview;
       const allChartsObj = {
-        ...overview,
-        ...(overview.extra_properties ?? {}),
+        ...extra_properties_ovw,
+        ...everything_else_ovw,
       };
-      if (allChartsObj.extra_properties) delete allChartsObj.extra_properties;
-
 
       let allCharts = Object.entries(allChartsObj)
         .filter(([_, value]) => isChartConfig(value))
         .map(([name, rawData]) => {
-          const properties = fields.find((e) => e.name === name)?.data;
-          const data = parseData({data: rawData, properties});
+          const properties = fieldMap[name];
+          const data = parseData({ data: rawData, properties });
           return {
             name,
             data,
             properties,
             isDisplayed: true,
-          }
+          };
         });
 
       // comparing to the local store and updating itself


### PR DESCRIPTION
How to test:
Using the following config.json for Katsu (notice: it does not contain `extra_properties`), load the current main branch for bento_public. Check that you can reproduce the bug where no data is displayed.
Update your repo to this branch and check that everything is displayed correctly.

```json
{
  "age": {
    "type": "number",
    "title": "Age",
    "bin_size": 10,
    "is_range": true,
    "queryable": true,
    "taper_left": 40,
    "taper_right": 60,
    "units": "years",
    "minimum": 0,
    "description": "Age at arrival"
  },
  "sex": {
    "type": "string",
    "enum": [
      "Male",
      "Female"
    ],
    "title": "Sex",
    "queryable": true,
    "description": "Sex at birth"
  },
  "experiment_type": {
    "type": "string",
    "title": "Experiment Types",
    "queriable": false,
    "description": "Types of experiments performed on a sample"
  }
}
```