### PR TITLE
Styling changes

### DIFF
--- a/src/js/components/Overview/OverviewDisplayData.js
+++ b/src/js/components/Overview/OverviewDisplayData.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
-import { Row, Col } from 'antd';
+import { Row, Col, Space } from 'antd';
 
 import MakeChartCard from './MakeChartCard';
 import { disableChart } from '../../features/data/data';
@@ -15,15 +15,15 @@ const OverviewDisplayData = ({ section, allCharts }) => {
   };
 
   return (
-    <Row>
+    <Row justify="center">
       <Col span={24}>
-        <div className="chart-grid">
+        <Space size={[15, 15]} wrap>
           {orderedCharts
             .filter((e) => e.isDisplayed)
             .map((chart) => (
               <MakeChartCard key={chart.name} chart={chart} section={section} onRemoveChart={onRemoveChart} />
             ))}
-        </div>
+        </Space>
       </Col>
     </Row>
   );

--- a/src/js/components/Overview/OverviewDisplayData.js
+++ b/src/js/components/Overview/OverviewDisplayData.js
@@ -1,12 +1,30 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { Row, Col, Space } from 'antd';
+import { List } from 'antd';
 
 import MakeChartCard from './MakeChartCard';
 import { disableChart } from '../../features/data/data';
 
+const getColumnCount = (width) => {
+  if (width < 990) {
+    return 1;
+  } else if (width < 1420) {
+    return 2;
+  } else return 3;
+};
+
+const getframeWidth = (width) => {
+  if (width < 990) {
+    return 360;
+  } else if (width < 1420) {
+    return 910;
+  } else return 1370;
+};
+
 const OverviewDisplayData = ({ section, allCharts }) => {
   const dispatch = useDispatch();
+
+  const { width } = useWindowSize();
 
   const orderedCharts = allCharts;
 
@@ -15,18 +33,36 @@ const OverviewDisplayData = ({ section, allCharts }) => {
   };
 
   return (
-    <Row justify="center">
-      <Col span={24}>
-        <Space size={[15, 15]} wrap>
-          {orderedCharts
-            .filter((e) => e.isDisplayed)
-            .map((chart) => (
-              <MakeChartCard key={chart.name} chart={chart} section={section} onRemoveChart={onRemoveChart} />
-            ))}
-        </Space>
-      </Col>
-    </Row>
+    <List
+      style={{ width: `${getframeWidth(width)}px` }}
+      grid={{ gutter: 0, column: getColumnCount(width) }}
+      dataSource={orderedCharts.filter((e) => e.isDisplayed)}
+      renderItem={(chart) => (
+        <MakeChartCard key={chart.name} chart={chart} section={section} onRemoveChart={onRemoveChart} />
+      )}
+    />
   );
+};
+
+const useWindowSize = () => {
+  const [windowSize, setWindowSize] = useState({
+    width: undefined,
+    height: undefined,
+  });
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    };
+    window.addEventListener('resize', handleResize);
+    handleResize();
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return windowSize;
 };
 
 export default OverviewDisplayData;

--- a/src/js/components/Overview/OverviewSection.js
+++ b/src/js/components/Overview/OverviewSection.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Typography, Row, Col } from 'antd';
+import { Typography, Space } from 'antd';
 import { useTranslation } from 'react-i18next';
 
 import OverviewDisplayData from './OverviewDisplayData';
@@ -8,12 +8,10 @@ const OverviewSection = ({ title, chartData }) => {
   const { t } = useTranslation();
 
   return (
-    <Row className="overview-section">
-      <Col span={24}>
-        <Typography.Title level={3}>{t(title)}</Typography.Title>
-        <OverviewDisplayData section={title} allCharts={chartData} />
-      </Col>
-    </Row>
+    <Space direction="vertical" size={0}>
+      <Typography.Title level={3}>{t(title)}</Typography.Title>
+      <OverviewDisplayData section={title} allCharts={chartData} />
+    </Space>
   );
 };
 

--- a/src/js/components/Overview/PublicOverview.js
+++ b/src/js/components/Overview/PublicOverview.js
@@ -20,32 +20,36 @@ const PublicOverview = () => {
   const [drawerVisible, setDrawerVisible] = useState(false);
 
   return (
-    <div className="container">
-      <div style={{ pointerEvents: 'none', color: '#AAA', position: 'absolute', top: '-5.5em', right: '3em' }}>
-        <Typography.Title level={5}>
-          {t('Individuals')}: {individuals}
-        </Typography.Title>
+    <>
+      <div className="container">
+        <div style={{ pointerEvents: 'none', color: '#AAA', position: 'absolute', top: '-5.5em', right: '3em' }}>
+          <Typography.Title level={5}>
+            {t('Individuals')}: {individuals}
+          </Typography.Title>
+        </div>
+        <Row justify="center">
+          <Col>
+            {sections.map(({ sectionTitle, charts }, i) => (
+              <div key={i} className="overview">
+                <OverviewSection index={i} title={sectionTitle} chartData={charts} />
+                <Divider />
+              </div>
+            ))}
+          </Col>
+        </Row>
       </div>
-      <Row justify="center">
-        <Col>
-          {sections.map(({ sectionTitle, charts }, i) => (
-            <div key={i} className="overview">
-              <OverviewSection index={i} title={sectionTitle} chartData={charts} />
-              <Divider />
-            </div>
-          ))}
-          <ManageChartsDrawer onManageDrawerClose={() => setDrawerVisible(false)} manageDrawerVisible={drawerVisible} />
-          <Button
-            type="primary"
-            shape="circle"
-            icon={<PlusOutlined />}
-            size="large"
-            className="floating-button"
-            onClick={() => setDrawerVisible(true)}
-          />
-        </Col>
-      </Row>
-    </div>
+
+      {/* Drawer & Button */}
+      <ManageChartsDrawer onManageDrawerClose={() => setDrawerVisible(false)} manageDrawerVisible={drawerVisible} />
+      <Button
+        type="primary"
+        shape="circle"
+        icon={<PlusOutlined />}
+        size="large"
+        className="floating-button"
+        onClick={() => setDrawerVisible(true)}
+      />
+    </>
   );
 };
 

--- a/src/js/components/Search/MakeQueryOption.js
+++ b/src/js/components/Search/MakeQueryOption.js
@@ -31,7 +31,7 @@ const MakeQueryOption = ({ queryField }) => {
 
   return (
     <>
-      <Row style={{ marginTop: '1rem' }}>
+      <Row style={{ width: '900px' }}>
         <Col span={3} offset={2}>
           <Checkbox id={id} checked={checked} onChange={onCheckToggle} disabled={disabled} />
         </Col>

--- a/src/js/components/Search/Search.js
+++ b/src/js/components/Search/Search.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Row, Col, Button, Typography } from 'antd';
+import { Row, Button, Typography, Space } from 'antd';
 import { useSelector, useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
@@ -18,39 +18,37 @@ const Search = () => {
 
   const queryKatsuPublic = () => {
     dispatch(makeGetKatsuPublic());
+    // scroll to top
+    window.scrollTo(0, 0);
   };
 
   return (
-    <Row justify="center">
-      <Col style={{ width: '900px' }}>
-        {searchSections.map((e, i) => (
-          <div key={i} style={{ marginBottom: '20px' }}>
-            <Typography.Title level={4}>{t(e.section_title)}</Typography.Title>
-            <SearchFieldsStack key={i} queryFields={e.fields} />
-          </div>
-        ))}
-        <Row justify="center">
-          <Col className="text-center">
-            <Button
-              type="primary"
-              onClick={queryKatsuPublic}
-              size="large"
-              shape="round"
-              loading={isFetchingData}
-              disabled={buttonDisabled}
-              style={{ margin: '20px' }}
-            >
-              {t('Get Data')}
-            </Button>
-          </Col>
-        </Row>
-        <Row justify="center">
-          <Col>
-            <SearchResults />
-          </Col>
-        </Row>
-      </Col>
-    </Row>
+    <>
+      <Row justify="center">
+        <Space direction="vertical">
+          <SearchResults />
+          <Space direction="vertical" size="large">
+            {searchSections.map((e, i) => (
+              <div key={i}>
+                <Typography.Title level={4}>{t(e.section_title)}</Typography.Title>
+                <SearchFieldsStack key={i} queryFields={e.fields} />
+              </div>
+            ))}
+          </Space>
+        </Space>
+      </Row>
+      <Button
+        type="primary"
+        onClick={queryKatsuPublic}
+        size="large"
+        shape="round"
+        loading={isFetchingData}
+        disabled={buttonDisabled}
+        className="floating-search"
+      >
+        {t('Get Data')}
+      </Button>
+    </>
   );
 };
 

--- a/src/js/components/Search/SearchFieldsStack.js
+++ b/src/js/components/Search/SearchFieldsStack.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import MakeQueryOption from './MakeQueryOption';
+import { Space } from 'antd';
 
 const SearchFieldsStack = ({ queryFields }) => {
   return (
-    <>
+    <Space direction="vertical" size="small">
       {queryFields.map((e, i) => (
         <MakeQueryOption key={i} queryField={e} />
       ))}
-    </>
+    </Space>
   );
 };
 

--- a/src/js/components/Search/SearchResults.js
+++ b/src/js/components/Search/SearchResults.js
@@ -26,7 +26,7 @@ const SearchResults = () => {
   const wrapperStyle = {
     padding: '40px',
     minHeight: '150px',
-    maxHeight: '150px',
+    maxHeight: '475px',
   };
 
   return (

--- a/src/js/components/SiteHeader.js
+++ b/src/js/components/SiteHeader.js
@@ -28,13 +28,13 @@ const SiteHeader = () => {
   return (
     <Header style={{ backgroundColor: '#fff' }}>
       <Row align="middle">
-        <Col span={2}>
-          <img style={{ height: '35px' }} src={bentoLogo} alt="logo" />
-        </Col>
-        <Col span={2}>
-          <Typography.Title style={{ marginBottom: '-4px' }} level={4} type="secondary">
-            {client}
-          </Typography.Title>
+        <Col span={4}>
+          <Space>
+            <img style={{ height: '35px' }} src={bentoLogo} alt="logo" />
+            <Typography.Title style={{ marginBottom: '-4px' }} level={4} type="secondary">
+              {client}
+            </Typography.Title>
+          </Space>
         </Col>
         <Col offset={18} span={2}>
           <Space>

--- a/src/js/constants/configConstants.js
+++ b/src/js/constants/configConstants.js
@@ -3,7 +3,7 @@ const { CLIENT, HOST, DEBUG } = process.env;
 export const debug = DEBUG.toLowerCase() === 'true';
 export const client = CLIENT;
 
-export const MAX_CHARTS = 9;
+export const MAX_CHARTS = 3;
 
 export const configUrl = HOST + '/config';
 export const publicOverviewUrl = HOST + '/overview';

--- a/src/styles.css
+++ b/src/styles.css
@@ -19,12 +19,6 @@ body {
     position: relative; /* used for positionning the counts */
 }
 
-.chart-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    grid-gap: 15px;
-}
-
 .floating-button {
   position:fixed;
   right:5em;
@@ -36,25 +30,4 @@ body {
     position:fixed;
     right:5em;
     bottom:3em;
-}
-
-@media only screen and (max-width: 1065px) {
-    .chart-grid {
-        grid-template-columns: repeat(1, 1fr);
-    }
-    .overview {
-        width: 350px;
-    }
-}
-
-@media only screen and (min-width: 1065px) and (max-width: 1490px) {
-
-    .chart-grid {
-        display: grid;
-        grid-template-columns: repeat(2, 1fr);
-        grid-gap: 15px;
-    }
-    .overview {
-        width: 815px;
-    }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -9,14 +9,10 @@ body {
   background-color: #eff2f5;
 }
 
-.overview-section {
-    margin: 0 40px;
-}
-
 .container {
     max-width: 1400px;
     margin: 0 auto;
-    position: relative; /* used for positionning the counts */
+    position: relative; /* used for positioning the counts */
 }
 
 .floating-button {
@@ -30,4 +26,5 @@ body {
     position:fixed;
     right:5em;
     bottom:3em;
+    transform: scale(125%);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -32,6 +32,12 @@ body {
   transform: scale(125%);
 }
 
+.floating-search {
+    position:fixed;
+    right:5em;
+    bottom:3em;
+}
+
 @media only screen and (max-width: 1065px) {
     .chart-grid {
         grid-template-columns: repeat(1, 1fr);


### PR DESCRIPTION
- moved the search results to the top
- moved get data to the side as a floating button
- Bento public logo and the text next to it now do not overlap on zoom or small screen
- made overview charts response and responds well to screen size change
- made default chart load for a section to 3