### PR TITLE
fix: language change with url param

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,12 @@ module.exports = {
     'no-unused-vars': 'off', // disable no-unused-vars since @typescript-eslint/no-unused-vars does the same
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }], // enable @typescript-eslint/no-unused-vars
     '@typescript-eslint/no-non-null-assertion': 'off',
+    "comma-dangle": ["error", {
+      "arrays": "always-multiline",
+      "objects": "always-multiline",
+      "imports": "always-multiline",
+      "exports": "always-multiline",
+  }],
   },
   settings: {
     react: {

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/*
 .prettierrc
 .idea/
 .vscode/
+www/

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build-dev": "webpack --mode=development",
     "watch": "webpack --mode=development --watch",
     "gobuild": "./buildandrun.sh",
-    "lint": "npx eslint \"src/js/**/*.{js,jsx,ts,tsx}\""
+    "lint": "npx eslint \"src/js/**/*.{js,jsx,ts,tsx}\"",
+    "lint-fix": "npx eslint --fix \"src/js/**/*.{js,jsx,ts,tsx}\""
   },
   "keywords": [],
   "author": "",

--- a/src/js/components/SiteHeader.tsx
+++ b/src/js/components/SiteHeader.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { Button, Layout, Row, Col, Typography, Space } from 'antd';
 const { Header } = Layout;
 import { useTranslation } from 'react-i18next';
-import { DEFAULT_TRANSLATION, LNG_CHANGE, LNGS_FULL_NAMES, SUPPORTED_LNGS } from '@/constants/configConstants';
+import { DEFAULT_TRANSLATION, LNG_CHANGE, LNGS_FULL_NAMES } from '@/constants/configConstants';
 import { useAppSelector } from '@/hooks';
 import { useNavigate, useLocation } from 'react-router-dom';
 

--- a/src/js/components/SiteHeader.tsx
+++ b/src/js/components/SiteHeader.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { Button, Layout, Row, Col, Typography, Space } from 'antd';
 const { Header } = Layout;
 import { useTranslation } from 'react-i18next';
-import { DEFAULT_TRANSLATION, langFullNames } from '@/constants/configConstants';
+import { DEFAULT_TRANSLATION, LNG_CHANGE, LNGS_FULL_NAMES, SUPPORTED_LNGS } from '@/constants/configConstants';
 import { useAppSelector } from '@/hooks';
 import { useNavigate, useLocation } from 'react-router-dom';
 
@@ -20,7 +20,7 @@ const SiteHeader = () => {
   }, [clientName]);
 
   const changeLanguage = () => {
-    const newLang = i18n.language === 'en' ? 'fr' : 'en';
+    const newLang = LNG_CHANGE[i18n.language];
     const path = (location.pathname + location.search).replace(`/${i18n.language}/`, `/${newLang}/`);
     navigate(path, { replace: true });
   };
@@ -43,7 +43,7 @@ const SiteHeader = () => {
           <Space>
             {translated && (
               <Button shape="round" onClick={changeLanguage}>
-                {i18n.language === 'en' ? langFullNames.fr : langFullNames.en}
+                {LNGS_FULL_NAMES[LNG_CHANGE[i18n.language]]}
               </Button>
             )}
             <Button type="primary" shape="round" onClick={buttonHandler}>

--- a/src/js/components/SiteHeader.tsx
+++ b/src/js/components/SiteHeader.tsx
@@ -1,14 +1,13 @@
 import React, { useEffect } from 'react';
 import { Button, Layout, Row, Col, Typography, Space } from 'antd';
 const { Header } = Layout;
-import i18n from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { DEFAULT_TRANSLATION, langFullNames } from '@/constants/configConstants';
 import { useAppSelector } from '@/hooks';
 import { useNavigate, useLocation } from 'react-router-dom';
 
 const SiteHeader = () => {
-  const { t } = useTranslation(DEFAULT_TRANSLATION);
+  const { t, i18n } = useTranslation(DEFAULT_TRANSLATION);
   const navigate = useNavigate();
   const location = useLocation();
 

--- a/src/js/constants/configConstants.ts
+++ b/src/js/constants/configConstants.ts
@@ -9,7 +9,18 @@ export const provenanceUrl = '/provenance';
 export const DEFAULT_TRANSLATION = 'default_translation';
 export const NON_DEFAULT_TRANSLATION = 'translation';
 
-export const langFullNames = {
-  en: 'English',
-  fr: 'Français',
+export const SUPPORTED_LNGS = {
+  ENGLISH: 'en',
+  FRENCH: 'fr',
+};
+
+// Language change from eng to fr, and vice-versa
+export const LNG_CHANGE = {
+  [SUPPORTED_LNGS.ENGLISH]: SUPPORTED_LNGS.FRENCH,
+  [SUPPORTED_LNGS.FRENCH]: SUPPORTED_LNGS.ENGLISH,
+};
+
+export const LNGS_FULL_NAMES = {
+  [SUPPORTED_LNGS.ENGLISH]: 'English',
+  [SUPPORTED_LNGS.FRENCH]: 'Français',
 };

--- a/src/js/i18n.ts
+++ b/src/js/i18n.ts
@@ -2,6 +2,7 @@ import i18n, { InitOptions } from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import HttpApi from 'i18next-http-backend';
+import { SUPPORTED_LNGS } from './constants/configConstants';
 
 const languageDetector = new LanguageDetector(null, {
   order: ['htmlTag', 'cookie', 'localStorage', 'path', 'subdomain'],
@@ -9,13 +10,13 @@ const languageDetector = new LanguageDetector(null, {
 });
 
 const options: InitOptions = {
-  fallbackLng: 'en',
+  fallbackLng: SUPPORTED_LNGS.ENGLISH,
 
   // have a common namespace used around the full app
   ns: ['translation', 'default_translation'],
   defaultNS: 'translation',
 
-  supportedLngs: ['en', 'fr'],
+  supportedLngs: Object.values(SUPPORTED_LNGS),
   load: 'all',
 
   debug: false,

--- a/src/js/index.tsx
+++ b/src/js/index.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { HashRouter, Routes, Route, useParams, useNavigate } from 'react-router-dom';
 import { Layout } from 'antd';
 import { ChartConfigProvider } from 'bento-charts';
+import { SUPPORTED_LNGS } from './constants/configConstants';
 
 import './i18n';
 import '../styles.css';
@@ -15,6 +16,7 @@ import SiteFooter from './components/SiteFooter';
 
 import { store } from './store';
 
+const LNGS_ARRAY = Object.values(SUPPORTED_LNGS);
 const { Content } = Layout;
 
 const App = () => {
@@ -23,10 +25,12 @@ const App = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (lang === 'en' || lang === 'fr') {
+    if (lang && LNGS_ARRAY.includes(lang)) {
       i18n.changeLanguage(lang);
     } else if (i18n.language) {
       navigate(`/${i18n.language}/`);
+    } else {
+      navigate(`/${SUPPORTED_LNGS.ENGLISH}/`);
     }
   }, [lang, i18n.language, navigate]);
 
@@ -48,7 +52,7 @@ const BentoApp = () => {
   console.log('i18n.language', i18n.language);
 
   return (
-    <ChartConfigProvider Lng={i18n.language ?? 'en'}>
+    <ChartConfigProvider Lng={i18n.language ?? SUPPORTED_LNGS.ENGLISH}>
       <Routes>
         <Route path="/:lang?/*" element={<App />} />
       </Routes>

--- a/src/js/index.tsx
+++ b/src/js/index.tsx
@@ -25,10 +25,10 @@ const App = () => {
   useEffect(() => {
     if (lang === 'en' || lang === 'fr') {
       i18n.changeLanguage(lang);
-    } else {
-      navigate(`/${i18n.language}`);
+    } else if (i18n.language) {
+      navigate(`/${i18n.language}/`);
     }
-  }, [lang, i18n, navigate]);
+  }, [lang, i18n.language, navigate]);
 
   return (
     <Layout>


### PR DESCRIPTION
**Issues**: After opening the site, we cant change the language until a route change is done

**Causes**: 
- In `src/js/index.tsx` the language url param was being set before i18n was initialized, causing it to be undefined (`/#/undefined`) until the next route change (when i18n.language is `en` or `fr`).
- Missing trailing `/` after language url param was preventing path replacement in `SiteHeader.changeLanguage`

**Other:**
- `SiteHeader.tsx` now accessing the i18n instance with the useTranslation hook
- added `www/` dir to .gitignore