### PR TITLE
fix: error when selecting query option + missing URL params in some cases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/labstack/echo v3.3.10+incompatible
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 )
 
 require (
@@ -12,7 +13,6 @@ require (
 	github.com/labstack/gommon v0.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.11 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
-	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/stretchr/testify v1.8.1 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bento_public",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bento_public",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@ant-design/icons": "^5.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bento_public",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "A publicly accessible portal for clinical datasets, where users are able to see high-level statistics of the data available through predefined variables of interest and search the data using limited variables at a time. This portal allows users to gain a generic understanding of the data available (secure and firewalled) without the need to access it directly. Initially, this portal facilitates the search in English language only, but the French language will be added at a later time.",
   "main": "index.js",
   "scripts": {

--- a/src/js/components/Search/MakeQueryOption.tsx
+++ b/src/js/components/Search/MakeQueryOption.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Row, Col, Checkbox } from 'antd';
 import { useTranslation } from 'react-i18next';
 
@@ -9,26 +9,16 @@ import SelectOption from './SelectOption';
 import { DEFAULT_TRANSLATION, NON_DEFAULT_TRANSLATION } from '@/constants/configConstants';
 import { useAppDispatch, useAppSelector } from '@/hooks';
 import { Field } from '@/types/search';
-import { useLocation, useNavigate } from 'react-router-dom';
 
 const MakeQueryOption = ({ queryField }: MakeQueryOptionProps) => {
   const { t } = useTranslation(NON_DEFAULT_TRANSLATION);
   const { t: td } = useTranslation(DEFAULT_TRANSLATION);
   const dispatch = useAppDispatch();
-  const navigate = useNavigate();
-  const location = useLocation();
 
   const { title, id, description, config, options } = queryField;
 
-  const [checkedCount, queryParams, maxCount] = useAppSelector((state) => [
-    state.query.queryParamCount,
-    state.query.queryParams,
-    state.config.maxQueryParameters,
-  ]);
-
-  useEffect(() => {
-    navigate(`${location.pathname}?${new URLSearchParams(queryParams).toString()}`, { replace: true });
-  }, [queryParams]);
+  const maxQueryParameters = useAppSelector((state) => state.config.maxQueryParameters);
+  const {queryParamCount, queryParams} = useAppSelector((state) => state.query);
 
   const isChecked = Object.prototype.hasOwnProperty.call(queryParams, id);
 
@@ -41,7 +31,7 @@ const MakeQueryOption = ({ queryField }: MakeQueryOptionProps) => {
     dispatch(makeGetKatsuPublic());
   };
 
-  const disabled = isChecked ? false : checkedCount >= maxCount;
+  const disabled = isChecked ? false : queryParamCount >= maxQueryParameters;
 
   return (
     <>

--- a/src/js/components/Search/MakeQueryOption.tsx
+++ b/src/js/components/Search/MakeQueryOption.tsx
@@ -18,7 +18,7 @@ const MakeQueryOption = ({ queryField }: MakeQueryOptionProps) => {
   const { title, id, description, config, options } = queryField;
 
   const maxQueryParameters = useAppSelector((state) => state.config.maxQueryParameters);
-  const {queryParamCount, queryParams} = useAppSelector((state) => state.query);
+  const { queryParamCount, queryParams } = useAppSelector((state) => state.query);
 
   const isChecked = Object.prototype.hasOwnProperty.call(queryParams, id);
 

--- a/src/js/components/Search/Search.tsx
+++ b/src/js/components/Search/Search.tsx
@@ -13,6 +13,9 @@ import { buildQueryParamsUrl } from '@/utils/search';
 
 import type { QueryParams } from '@/types/search';
 
+const checkQueryParamsEqual = (qp1: QueryParams, qp2: QueryParams): boolean =>
+  [...new Set(...Object.keys(qp1), ...Object.keys(qp2))].reduce((acc, v) => acc && qp1[v] === qp2[v], true);
+
 const RoutedSearch: React.FC = () => {
   const dispatch = useAppDispatch();
   const location = useLocation();
@@ -57,8 +60,11 @@ const RoutedSearch: React.FC = () => {
     const queryParam = new URLSearchParams(location.search);
     const { valid, validQueryParamsObject } = validateQuery(queryParam);
     if (valid) {
-      dispatch(setQueryParams(validQueryParamsObject));
-      dispatch(makeGetKatsuPublic());
+      if (!checkQueryParamsEqual(validQueryParamsObject, queryParams)) {
+        // Only update the state & refresh if we have a new set of query params from the URL.
+        dispatch(setQueryParams(validQueryParamsObject));
+        dispatch(makeGetKatsuPublic());
+      }
     } else {
       console.debug('Redirecting to : ', buildQueryParamsUrl(location.pathname, validQueryParamsObject));
       navigate(buildQueryParamsUrl(location.pathname, validQueryParamsObject));

--- a/src/js/components/Search/Search.tsx
+++ b/src/js/components/Search/Search.tsx
@@ -27,9 +27,10 @@ const RoutedSearch: React.FC = () => {
     isFetchingFields: isFetchingSearchFields,
   } = useAppSelector((state) => state.query);
 
-  const searchFields = useMemo(() => searchSections.flatMap(({ fields }) =>
-    fields.map((field) => ({ id: field.id, options: field.options }))
-  ), [searchSections]);
+  const searchFields = useMemo(
+    () => searchSections.flatMap(({ fields }) => fields.map((field) => ({ id: field.id, options: field.options }))),
+    [searchSections]
+  );
 
   const validateQuery = (query: URLSearchParams): { valid: boolean; validQueryParamsObject: QueryParams } => {
     const validateQueryParam = (key: string, value: string): boolean => {
@@ -54,7 +55,7 @@ const RoutedSearch: React.FC = () => {
   // Synchronize Redux query params state from URL
   useEffect(() => {
     if (isFetchingSearchFields) return;
-    if (!location.pathname.endsWith("/search")) return;
+    if (!location.pathname.endsWith('/search')) return;
     const queryParam = new URLSearchParams(location.search);
     const { valid, validQueryParamsObject } = validateQuery(queryParam);
     if (valid) {
@@ -68,7 +69,7 @@ const RoutedSearch: React.FC = () => {
 
   // Synchronize URL from Redux query params state
   useEffect(() => {
-    if (!location.pathname.endsWith("/search")) return;
+    if (!location.pathname.endsWith('/search')) return;
     navigate(buildQueryParamsUrl(location.pathname, queryParams), { replace: true });
   }, [queryParams]);
 

--- a/src/js/components/Search/Search.tsx
+++ b/src/js/components/Search/Search.tsx
@@ -1,19 +1,17 @@
 import React, { useEffect, useMemo } from 'react';
 import { Row, Typography, Space, FloatButton } from 'antd';
 import { useTranslation } from 'react-i18next';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import SearchFieldsStack from './SearchFieldsStack';
 import SearchResults from './SearchResults';
 
-import { makeGetKatsuPublic, setQueryParams } from '@/features/search/query.store';
 import { NON_DEFAULT_TRANSLATION } from '@/constants/configConstants';
+import { makeGetKatsuPublic, setQueryParams } from '@/features/search/query.store';
 import { useAppDispatch, useAppSelector } from '@/hooks';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { buildQueryParamsUrl } from '@/utils/search';
 
-type QueryParams = { [key: string]: string };
-
-const buildQueryParamsUrl = (pathName: string, qp: QueryParams): string =>
-  `${pathName}?${new URLSearchParams(qp).toString()}`;
+import type { QueryParams } from '@/types/search';
 
 const RoutedSearch: React.FC = () => {
   const dispatch = useAppDispatch();

--- a/src/js/components/Search/Search.tsx
+++ b/src/js/components/Search/Search.tsx
@@ -14,8 +14,6 @@ type QueryParams = { [key: string]: string };
 
 const buildQueryParamsUrl = (pathName: string, qp: QueryParams): string =>
   `${pathName}?${new URLSearchParams(qp).toString()}`;
-const checkQueryParamsEqual = (qp1: QueryParams, qp2: QueryParams): boolean =>
-  [...new Set(...Object.keys(qp1), ...Object.keys(qp2))].reduce((acc, v) => acc && qp1[v] === qp2[v], true);
 
 const RoutedSearch: React.FC = () => {
   const dispatch = useAppDispatch();
@@ -60,11 +58,8 @@ const RoutedSearch: React.FC = () => {
     const queryParam = new URLSearchParams(location.search);
     const { valid, validQueryParamsObject } = validateQuery(queryParam);
     if (valid) {
-      if (!checkQueryParamsEqual(validQueryParamsObject, queryParams)) {
-        // Only update the state & refresh if we have a new set of query params from the URL.
-        dispatch(setQueryParams(validQueryParamsObject));
-        dispatch(makeGetKatsuPublic());
-      }
+      dispatch(setQueryParams(validQueryParamsObject));
+      dispatch(makeGetKatsuPublic());
     } else {
       console.debug('Redirecting to : ', buildQueryParamsUrl(location.pathname, validQueryParamsObject));
       navigate(buildQueryParamsUrl(location.pathname, validQueryParamsObject));

--- a/src/js/components/Search/Search.tsx
+++ b/src/js/components/Search/Search.tsx
@@ -26,6 +26,7 @@ const RoutedSearch: React.FC = () => {
     querySections: searchSections,
     queryParams,
     isFetchingFields: isFetchingSearchFields,
+    attemptedFetch,
   } = useAppSelector((state) => state.query);
 
   const searchFields = useMemo(
@@ -60,7 +61,7 @@ const RoutedSearch: React.FC = () => {
     const queryParam = new URLSearchParams(location.search);
     const { valid, validQueryParamsObject } = validateQuery(queryParam);
     if (valid) {
-      if (!checkQueryParamsEqual(validQueryParamsObject, queryParams)) {
+      if (!attemptedFetch || !checkQueryParamsEqual(validQueryParamsObject, queryParams)) {
         // Only update the state & refresh if we have a new set of query params from the URL.
         dispatch(setQueryParams(validQueryParamsObject));
         dispatch(makeGetKatsuPublic());
@@ -74,6 +75,7 @@ const RoutedSearch: React.FC = () => {
   // Synchronize URL from Redux query params state
   useEffect(() => {
     if (!location.pathname.endsWith('/search')) return;
+    if (!attemptedFetch) return;
     navigate(buildQueryParamsUrl(location.pathname, queryParams), { replace: true });
   }, [queryParams]);
 

--- a/src/js/components/TabbedDashboard.tsx
+++ b/src/js/components/TabbedDashboard.tsx
@@ -48,6 +48,9 @@ const TabbedDashboard = () => {
       const currentPathParts = currentPath.split('/');
       const currentLang = currentPathParts[1];
       const newPath = `/${currentLang}/${key === 'overview' ? '' : key}`;
+      // If we're going to the search page, insert query params into the URL pulled from the Redux state.
+      // This is important to keep the URL updated if we've searched something, navigated away, and now
+      // are returning to the search page.
       navigate(key === 'search' ? buildQueryParamsUrl(newPath, queryParams) : newPath);
     },
     [location, navigate, queryParams]

--- a/src/js/components/TabbedDashboard.tsx
+++ b/src/js/components/TabbedDashboard.tsx
@@ -19,6 +19,7 @@ import ProvenanceTab from './Provenance/ProvenanceTab';
 import BeaconQueryUi from './Beacon/BeaconQueryUi';
 import { DEFAULT_TRANSLATION } from '@/constants/configConstants';
 import { useAppDispatch, useAppSelector } from '@/hooks';
+import { buildQueryParamsUrl } from '@/utils/search';
 
 const TabbedDashboard = () => {
   const dispatch = useAppDispatch();
@@ -37,6 +38,7 @@ const TabbedDashboard = () => {
 
   const isFetchingOverviewData = useAppSelector((state) => state.data.isFetchingData);
   const isFetchingSearchFields = useAppSelector((state) => state.query.isFetchingFields);
+  const queryParams = useAppSelector((state) => state.query.queryParams);
   const isFetchingBeaconConfig = useAppSelector((state) => state.beaconConfig?.isFetchingBeaconConfig);
   const renderBeaconUi = useAppSelector((state) => state.config?.beaconUiEnabled);
 
@@ -46,9 +48,9 @@ const TabbedDashboard = () => {
       const currentPathParts = currentPath.split('/');
       const currentLang = currentPathParts[1];
       const newPath = `/${currentLang}/${key === 'overview' ? '' : key}`;
-      navigate(newPath);
+      navigate(key === 'search' ? buildQueryParamsUrl(newPath, queryParams) : newPath);
     },
-    [location, navigate]
+    [location, navigate, queryParams]
   );
 
   const TabTitle = ({ title }: { title: string }) => (

--- a/src/js/features/search/query.store.ts
+++ b/src/js/features/search/query.store.ts
@@ -5,9 +5,10 @@ import { serializeChartData } from '@/utils/chart';
 import { KatsuSearchResponse, SearchFieldResponse } from '@/types/search';
 import { ChartData } from '@/types/data';
 
-type queryState = {
+type QueryState = {
   isFetchingFields: boolean;
   isFetchingData: boolean;
+  attemptedFetch: boolean;
   querySections: SearchFieldResponse['sections'];
   queryParams: { [key: string]: string };
   queryParamCount: number;
@@ -20,9 +21,10 @@ type queryState = {
   individualCount: number;
 };
 
-const initialState: queryState = {
+const initialState: QueryState = {
   isFetchingFields: true,
   isFetchingData: false,
+  attemptedFetch: false,
   message: '',
   querySections: [],
   queryParams: {},
@@ -63,6 +65,7 @@ const query = createSlice({
     });
     builder.addCase(makeGetKatsuPublic.fulfilled, (state, { payload }: PayloadAction<KatsuSearchResponse>) => {
       state.isFetchingData = false;
+      state.attemptedFetch = true;
       if ('message' in payload) {
         state.message = payload.message;
         return;
@@ -76,6 +79,7 @@ const query = createSlice({
     });
     builder.addCase(makeGetKatsuPublic.rejected, (state) => {
       state.isFetchingData = false;
+      state.attemptedFetch = true;
     });
     builder.addCase(makeGetSearchFields.pending, (state) => {
       state.isFetchingFields = true;

--- a/src/js/types/search.ts
+++ b/src/js/types/search.ts
@@ -1,5 +1,7 @@
 import { Datum } from '@/types/overviewResponse';
 
+export type QueryParams = { [key: string]: string };
+
 export interface SearchFieldResponse {
   sections: Section[];
 }

--- a/src/js/utils/search.ts
+++ b/src/js/utils/search.ts
@@ -1,0 +1,4 @@
+import { QueryParams } from '@/types/search';
+
+export const buildQueryParamsUrl = (pathName: string, qp: QueryParams): string =>
+  `${pathName}?${new URLSearchParams(qp).toString()}`;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "strictNullChecks": true,
     "module": "es6",
     "target": "es5",
-    "downlevelIteration": true,
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "strictNullChecks": true,
     "module": "es6",
     "target": "es5",
+    "downlevelIteration": true,
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
- fix: error when selecting query option + bad selectors
- fix: include query parameters when returning to search page
- refact: move search URL-handling logic to a single location