### PR TITLE
fix: chart click nav

### DIFF
--- a/src/js/components/Search/Search.tsx
+++ b/src/js/components/Search/Search.tsx
@@ -18,7 +18,7 @@ const checkQueryParamsEqual = (qp1: QueryParams, qp2: QueryParams): boolean => {
   const qp2Keys = Object.keys(qp2);
   const params = [...new Set([...qp1Keys, ...qp2Keys])];
   return params.reduce((acc, v) => acc && qp1[v] === qp2[v], true);
-}
+};
 
 const RoutedSearch: React.FC = () => {
   const dispatch = useAppDispatch();
@@ -65,10 +65,6 @@ const RoutedSearch: React.FC = () => {
     const queryParam = new URLSearchParams(location.search);
     const { valid, validQueryParamsObject } = validateQuery(queryParam);
     if (valid) {
-      console.log({
-        valid: validQueryParamsObject,
-        params: queryParams
-      });
       if (!attemptedFetch || !checkQueryParamsEqual(validQueryParamsObject, queryParams)) {
         // Only update the state & refresh if we have a new set of query params from the URL.
         dispatch(setQueryParams(validQueryParamsObject));

--- a/src/js/components/Search/Search.tsx
+++ b/src/js/components/Search/Search.tsx
@@ -13,8 +13,12 @@ import { buildQueryParamsUrl } from '@/utils/search';
 
 import type { QueryParams } from '@/types/search';
 
-const checkQueryParamsEqual = (qp1: QueryParams, qp2: QueryParams): boolean =>
-  [...new Set(...Object.keys(qp1), ...Object.keys(qp2))].reduce((acc, v) => acc && qp1[v] === qp2[v], true);
+const checkQueryParamsEqual = (qp1: QueryParams, qp2: QueryParams): boolean => {
+  const qp1Keys = Object.keys(qp1);
+  const qp2Keys = Object.keys(qp2);
+  const params = [...new Set([...qp1Keys, ...qp2Keys])];
+  return params.reduce((acc, v) => acc && qp1[v] === qp2[v], true);
+}
 
 const RoutedSearch: React.FC = () => {
   const dispatch = useAppDispatch();
@@ -61,6 +65,10 @@ const RoutedSearch: React.FC = () => {
     const queryParam = new URLSearchParams(location.search);
     const { valid, validQueryParamsObject } = validateQuery(queryParam);
     if (valid) {
+      console.log({
+        valid: validQueryParamsObject,
+        params: queryParams
+      });
       if (!attemptedFetch || !checkQueryParamsEqual(validQueryParamsObject, queryParams)) {
         // Only update the state & refresh if we have a new set of query params from the URL.
         dispatch(setQueryParams(validQueryParamsObject));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,9 +43,7 @@ const config = {
       inject: false,
     }),
     new CopyWebpackPlugin({
-      patterns: [
-        { from: 'src/public', to: 'public' },
-      ],
+      patterns: [{ from: 'src/public', to: 'public' }],
     }),
   ],
   optimization: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,7 +43,10 @@ const config = {
       inject: false,
     }),
     new CopyWebpackPlugin({
-      patterns: [{ from: 'src/public', to: 'public' }],
+      patterns: [
+        { from: 'src/public', to: 'public' },
+        { from: 'www/public', to: 'public'},
+      ],
     }),
   ],
   optimization: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,7 +45,6 @@ const config = {
     new CopyWebpackPlugin({
       patterns: [
         { from: 'src/public', to: 'public' },
-        { from: 'www/public', to: 'public'},
       ],
     }),
   ],


### PR DESCRIPTION
Chart click navigation was failing due to a faulty query parameters check (Search.tsx checkQueryParamsEqual).
Given the parameter "age", the function would spread each letter as its own parameter ("a", "g", "e"), causing `undefined === undefined` which evaluates to true always.