### PR TITLE
Features/beacon hide variants search

### DIFF
--- a/src/js/components/Beacon/AssemblyIdSelect.tsx
+++ b/src/js/components/Beacon/AssemblyIdSelect.tsx
@@ -14,7 +14,9 @@ const AssemblyIdSelect = ({ field, beaconAssemblyIds, disabled }: AssemblyIdSele
 
   return (
     <Form.Item name={field.name} label={td(field.name)} rules={field.rules}>
-      <Select style={{ width: '100%' }} disabled={disabled}>{assemblyIdOptions}</Select>
+      <Select style={{ width: '100%' }} disabled={disabled}>
+        {assemblyIdOptions}
+      </Select>
     </Form.Item>
   );
 };

--- a/src/js/components/Beacon/AssemblyIdSelect.tsx
+++ b/src/js/components/Beacon/AssemblyIdSelect.tsx
@@ -4,7 +4,7 @@ import { Form, Select } from 'antd';
 import { FormField, BeaconAssemblyIds } from '@/types/beacon';
 import { DEFAULT_TRANSLATION } from '@/constants/configConstants';
 
-const AssemblyIdSelect = ({ field, beaconAssemblyIds }: AssemblyIdSelectProps) => {
+const AssemblyIdSelect = ({ field, beaconAssemblyIds, disabled }: AssemblyIdSelectProps) => {
   const { t: td } = useTranslation(DEFAULT_TRANSLATION);
   const assemblyIdOptions = beaconAssemblyIds.map((assembly) => (
     <Select.Option key={assembly} value={assembly}>
@@ -14,7 +14,7 @@ const AssemblyIdSelect = ({ field, beaconAssemblyIds }: AssemblyIdSelectProps) =
 
   return (
     <Form.Item name={field.name} label={td(field.name)} rules={field.rules}>
-      <Select style={{ width: '100%' }}>{assemblyIdOptions}</Select>
+      <Select style={{ width: '100%' }} disabled={disabled}>{assemblyIdOptions}</Select>
     </Form.Item>
   );
 };
@@ -22,6 +22,7 @@ const AssemblyIdSelect = ({ field, beaconAssemblyIds }: AssemblyIdSelectProps) =
 export interface AssemblyIdSelectProps {
   field: FormField;
   beaconAssemblyIds: BeaconAssemblyIds;
+  disabled: boolean;
 }
 
 export default AssemblyIdSelect;

--- a/src/js/components/Beacon/BeaconQueryUi.tsx
+++ b/src/js/components/Beacon/BeaconQueryUi.tsx
@@ -42,7 +42,7 @@ const BeaconQueryUi = () => {
   const dispatch = useAppDispatch();
   const launchEmptyQuery = () => dispatch(makeBeaconQuery(requestPayload({}, [])));
   const formInitialValues = { 'Assembly ID': beaconAssemblyIds.length === 1 && beaconAssemblyIds[0] };
-  const uiInstructions = hasVariants? 'Search by genomic variants, clinical metadata or both.': '';
+  const uiInstructions = hasVariants ? 'Search by genomic variants, clinical metadata or both.' : '';
 
   useEffect(() => {
     // wait for config
@@ -53,7 +53,7 @@ const BeaconQueryUi = () => {
     // retrieve stats
     launchEmptyQuery();
 
-    setHasVariants(beaconAssemblyIds.length > 0 );
+    setHasVariants(beaconAssemblyIds.length > 0);
 
     // set assembly id options matching what's in gohan
     form.setFieldsValue(formInitialValues);
@@ -145,18 +145,20 @@ const BeaconQueryUi = () => {
         <p style={{ margin: '-8px 0 8px 0', padding: '0', color: 'grey' }}>{td(uiInstructions)}</p>
         <Form form={form} onFinish={handleFinish} layout="vertical">
           <Row gutter={FORM_ROW_GUTTERS}>
-            {hasVariants && <Col xs={24} lg={12}>
-              <Card
-                title={td('Variants')}
-                style={CARD_STYLE}
-                headStyle={CARD_HEAD_STYLE}
-                bodyStyle={CARD_BODY_STYLE}
-                extra={<SearchToolTip text={VARIANTS_HELP} />}
-              >
-                <VariantsForm beaconAssemblyIds={beaconAssemblyIds} />
-              </Card>
-            </Col>}
-            <Col xs={24} lg={hasVariants? 12: 24}>
+            {hasVariants && (
+              <Col xs={24} lg={12}>
+                <Card
+                  title={td('Variants')}
+                  style={CARD_STYLE}
+                  headStyle={CARD_HEAD_STYLE}
+                  bodyStyle={CARD_BODY_STYLE}
+                  extra={<SearchToolTip text={VARIANTS_HELP} />}
+                >
+                  <VariantsForm beaconAssemblyIds={beaconAssemblyIds} />
+                </Card>
+              </Col>
+            )}
+            <Col xs={24} lg={hasVariants ? 12 : 24}>
               <Card
                 title={td('Metadata')}
                 style={CARD_STYLE}

--- a/src/js/components/Beacon/VariantInput.tsx
+++ b/src/js/components/Beacon/VariantInput.tsx
@@ -4,12 +4,12 @@ import { Form, Input } from 'antd';
 import { FormField } from '@/types/beacon';
 import { DEFAULT_TRANSLATION } from '@/constants/configConstants';
 
-const VariantInput = ({ field }: VariantInputProps) => {
+const VariantInput = ({ field, disabled }: VariantInputProps) => {
   const { t: td } = useTranslation(DEFAULT_TRANSLATION);
   return (
     <div>
       <Form.Item name={field.name} label={td(field.name)} rules={field.rules}>
-        <Input placeholder={field.placeholder} />
+        <Input placeholder={field.placeholder} disabled={disabled}/>
       </Form.Item>
     </div>
   );
@@ -17,6 +17,7 @@ const VariantInput = ({ field }: VariantInputProps) => {
 
 export interface VariantInputProps {
   field: FormField;
+  disabled: boolean;
 }
 
 export default VariantInput;

--- a/src/js/components/Beacon/VariantInput.tsx
+++ b/src/js/components/Beacon/VariantInput.tsx
@@ -9,7 +9,7 @@ const VariantInput = ({ field, disabled }: VariantInputProps) => {
   return (
     <div>
       <Form.Item name={field.name} label={td(field.name)} rules={field.rules}>
-        <Input placeholder={field.placeholder} disabled={disabled}/>
+        <Input placeholder={field.placeholder} disabled={disabled} />
       </Form.Item>
     </div>
   );

--- a/src/js/components/Beacon/VariantsForm.tsx
+++ b/src/js/components/Beacon/VariantsForm.tsx
@@ -86,7 +86,11 @@ const VariantsForm = ({ beaconAssemblyIds }: VariantsFormProps) => {
           <VariantInput field={formFields.alternateBases} disabled={variantsError} />
         </Col>
         <Col span={8}>
-          <AssemblyIdSelect field={formFields.assemblyId} beaconAssemblyIds={beaconAssemblyIds} disabled={variantsError} />
+          <AssemblyIdSelect
+            field={formFields.assemblyId}
+            beaconAssemblyIds={beaconAssemblyIds}
+            disabled={variantsError}
+          />
         </Col>
       </Row>
     </div>

--- a/src/js/components/Beacon/VariantsForm.tsx
+++ b/src/js/components/Beacon/VariantsForm.tsx
@@ -65,26 +65,28 @@ const VariantsForm = ({ beaconAssemblyIds }: VariantsFormProps) => {
     assemblyId: { name: 'Assembly ID', rules: [{}], placeholder: '', initialValue: '' },
   };
 
+  const variantsError = beaconAssemblyIds.includes('error');
+
   return (
     <div style={FORM_STYLE}>
       <Row gutter={FORM_ROW_GUTTER}>
         <Col span={8}>
-          <VariantInput field={formFields.referenceName} />
+          <VariantInput field={formFields.referenceName} disabled={variantsError} />
         </Col>
         <Col span={8}>
-          <VariantInput field={formFields.start} />
+          <VariantInput field={formFields.start} disabled={variantsError} />
         </Col>
         <Col span={8}>
-          <VariantInput field={formFields.end} />
+          <VariantInput field={formFields.end} disabled={variantsError} />
         </Col>
         <Col span={8}>
-          <VariantInput field={formFields.referenceBases} />
+          <VariantInput field={formFields.referenceBases} disabled={variantsError} />
         </Col>
         <Col span={8}>
-          <VariantInput field={formFields.alternateBases} />
+          <VariantInput field={formFields.alternateBases} disabled={variantsError} />
         </Col>
         <Col span={8}>
-          <AssemblyIdSelect field={formFields.assemblyId} beaconAssemblyIds={beaconAssemblyIds} />
+          <AssemblyIdSelect field={formFields.assemblyId} beaconAssemblyIds={beaconAssemblyIds} disabled={variantsError} />
         </Col>
       </Row>
     </div>

--- a/src/js/features/beacon/beaconConfig.store.ts
+++ b/src/js/features/beacon/beaconConfig.store.ts
@@ -34,9 +34,7 @@ const beaconConfig = createSlice({
       state.isFetchingBeaconConfig = true;
     });
     builder.addCase(getBeaconConfig.fulfilled, (state, { payload }) => {
-      // extract config values here instead of saving the entire thing
-      const assemblyIds = Object.keys(payload.response?.overview?.counts?.variants ?? []);
-      state.beaconAssemblyIds = assemblyIds.filter(id => id != "error")
+      state.beaconAssemblyIds = Object.keys(payload.response?.overview?.counts?.variants ?? []);
       state.isFetchingBeaconConfig = false;
     });
     builder.addCase(getBeaconConfig.rejected, (state) => {

--- a/src/js/features/beacon/beaconConfig.store.ts
+++ b/src/js/features/beacon/beaconConfig.store.ts
@@ -35,7 +35,8 @@ const beaconConfig = createSlice({
     });
     builder.addCase(getBeaconConfig.fulfilled, (state, { payload }) => {
       // extract config values here instead of saving the entire thing
-      state.beaconAssemblyIds = Object.keys(payload.response?.overview?.counts?.variants ?? []);
+      const assemblyIds = Object.keys(payload.response?.overview?.counts?.variants ?? []);
+      state.beaconAssemblyIds = assemblyIds.filter(id => id != "error")
       state.isFetchingBeaconConfig = false;
     });
     builder.addCase(getBeaconConfig.rejected, (state) => {

--- a/src/js/features/beacon/beaconConfig.store.ts
+++ b/src/js/features/beacon/beaconConfig.store.ts
@@ -35,7 +35,7 @@ const beaconConfig = createSlice({
     });
     builder.addCase(getBeaconConfig.fulfilled, (state, { payload }) => {
       // extract config values here instead of saving the entire thing
-      state.beaconAssemblyIds = Object.keys(payload.response?.overview?.counts?.variants ?? {});
+      state.beaconAssemblyIds = Object.keys(payload.response?.overview?.counts?.variants ?? []);
       state.isFetchingBeaconConfig = false;
     });
     builder.addCase(getBeaconConfig.rejected, (state) => {


### PR DESCRIPTION
First pass at conditional rendering of variants search form in Beacon tab:

- if there are no variants in the beacon, hide the variants form
- if variants are expected but gohan is down, returning errors, or claims there are no variants, show the variants form but disable it. 

(Variants are expected when beacon_config.json has param `useGohan=true`)