### PR TITLE
apply translation to metadata tooltip text

### DIFF
--- a/src/js/components/Beacon/BeaconQueryUi.tsx
+++ b/src/js/components/Beacon/BeaconQueryUi.tsx
@@ -232,7 +232,7 @@ const BeaconQueryUi = () => {
     </Space>
   );
 
-  const metadataInstructions = <ToolTipText>{METADATA_INSTRUCTIONS}</ToolTipText>;
+  const metadataInstructions = <ToolTipText>{td(METADATA_INSTRUCTIONS)}</ToolTipText>;
   const isFetchingBeaconQuery = useAppSelector((state) => state.beaconQuery.isFetchingQueryResponse);
 
   return (


### PR DESCRIPTION
Translation exists already, but `td()` was missing. 