### PR TITLE
beacon UI: translate search category name

### DIFF
--- a/src/js/components/Beacon/Filter.tsx
+++ b/src/js/components/Beacon/Filter.tsx
@@ -46,7 +46,7 @@ const Filter = ({ filter, form, querySections, removeFilter, isRequired }: Filte
 
   const searchKeyOptions = (arr: Section[]): FilterOption[] => {
     return arr.map((qs) => ({
-      label: qs.section_title,
+      label: t(qs.section_title),
       options: qs.fields.map((field) => ({
         label: renderLabel(field),
         value: field.id,


### PR DESCRIPTION
Another string snuck through untranslated, this time the search category (eg "Experiments", "Lab Results" etc depending on the instance).