### PR TITLE
beacon: remove form rules for assembly ID

### DIFF
--- a/src/js/components/Beacon/VariantsForm.tsx
+++ b/src/js/components/Beacon/VariantsForm.tsx
@@ -59,7 +59,7 @@ const VariantsForm = ({ beaconAssemblyIds }: VariantsFormProps) => {
       placeholder: `A, C, G, T ${td('or')} N`,
       initialValue: '',
     },
-    assemblyId: { name: 'Assembly ID', rules: [{}], placeholder: '', initialValue: '' },
+    assemblyId: { name: 'Assembly ID', placeholder: '', initialValue: '' },
   };
 
   const variantsError = beaconAssemblyIds.includes('error');

--- a/src/js/types/beacon.ts
+++ b/src/js/types/beacon.ts
@@ -9,7 +9,7 @@ export type BeaconAssemblyIds = string[];
 
 export interface FormField {
   name: string;
-  rules: Rule[];
+  rules?: Rule[];
   placeholder: string;
   initialValue: string;
 }


### PR DESCRIPTION
Remove blank "rules" array for assembly ID in variants search form (Redmine [#2010](https://206.12.92.46/issues/2010)):
- it's not needed, since there are no rules to apply (probably the form was originally built using a `map()` call, so it was put there for consistency with the other fields)
- having rules here breaks the form when the assembly ID field is empty (which can happen if more than one assembly is present): antd tries and fails to apply the rules to a blank field, even though there are no rules to apply. Since the way to search metadata only is to leave the variants form blank, blank fields need to be handled correctly.

