### PR TITLE
beacon: use a different overview endpoint

### DIFF
--- a/src/js/features/beacon/beaconConfig.store.ts
+++ b/src/js/features/beacon/beaconConfig.store.ts
@@ -7,7 +7,7 @@ import { printAPIError } from '@/utils/error.util';
 export const getBeaconConfig = createAsyncThunk<BeaconConfigResponse, void, { state: RootState; rejectValue: string }>(
   'beaconConfig/getBeaconConfig',
   (_, { getState, rejectWithValue }) => {
-    const beaconInfoEndpoint = getState()?.config?.beaconUrl + '/overview';
+    const beaconInfoEndpoint = getState().config.beaconUrl + '/overview';
     return axios
       .get(beaconInfoEndpoint)
       .then((res) => res.data)

--- a/src/js/features/beacon/beaconConfig.store.ts
+++ b/src/js/features/beacon/beaconConfig.store.ts
@@ -7,7 +7,7 @@ import { printAPIError } from '@/utils/error.util';
 export const getBeaconConfig = createAsyncThunk<BeaconConfigResponse, void, { state: RootState; rejectValue: string }>(
   'beaconConfig/getBeaconConfig',
   (_, { getState, rejectWithValue }) => {
-    const beaconInfoEndpoint = getState()?.config?.beaconUrl + '/info';
+    const beaconInfoEndpoint = getState()?.config?.beaconUrl + '/overview';
     return axios
       .get(beaconInfoEndpoint)
       .then((res) => res.data)

--- a/src/js/features/beacon/beaconQuery.store.ts
+++ b/src/js/features/beacon/beaconQuery.store.ts
@@ -11,7 +11,7 @@ export const makeBeaconQuery = createAsyncThunk<
   BeaconQueryPayload,
   { state: RootState; rejectValue: string }
 >('beaconQuery/makeBeaconQuery', async (payload, { getState, rejectWithValue }) => {
-  const beaconIndividualsEndpoint = getState()?.config?.beaconUrl + '/individuals';
+  const beaconIndividualsEndpoint = getState().config.beaconUrl + '/individuals';
   return axios
     .post(beaconIndividualsEndpoint, payload)
     .then((res) => res.data)


### PR DESCRIPTION
Change beacon overview endpoint to `/overview` (Redmine [#1859](https://206.12.92.46/issues/1859))