### PR TITLE
patch condition for parsing beacon response

### DIFF
--- a/src/js/features/beacon/beaconQuery.store.ts
+++ b/src/js/features/beacon/beaconQuery.store.ts
@@ -53,7 +53,7 @@ const beaconQuery = createSlice({
       state.isFetchingQueryResponse = true;
     });
     builder.addCase(makeBeaconQuery.fulfilled, (state, { payload }) => {
-      if (payload.info) {
+      if (payload.info?.bento) {
         state.biosampleCount = payload.info.bento?.biosamples?.count;
         state.biosampleChartData = serializeChartData(payload.info.bento?.biosamples?.sampled_tissue);
         state.experimentCount = payload.info.bento?.experiments?.count;


### PR DESCRIPTION
Patch condition for parsing the summary statistics part of the beacon response. Previously if `info` existed in the response, then so did `info.bento`, but this is no longer the case. See Redmine [#2080](https://206.12.92.46/issues/2080?issue_count=20&issue_position=1&next_issue_id=2068).