### PR TITLE
style: fix top margins on search overview chart headings

### DIFF
--- a/src/js/components/Search/SearchResultsPane.tsx
+++ b/src/js/components/Search/SearchResultsPane.tsx
@@ -29,6 +29,8 @@ const SearchResultsPane = ({
           padding: '10px 33px',
           maxWidth: '1200px',
           width: '100%',
+          // Set a minimum height (i.e., an expected final height, which can be exceeded) to prevent this component from
+          // suddenly increasing in height after it loads. This is calculated from the sum of the following parts:
           //   chart (300)
           // + heading (24 + 8 [0.5em] bottom margin)
           // + card body padding (2*24 = 48)

--- a/src/js/components/Search/SearchResultsPane.tsx
+++ b/src/js/components/Search/SearchResultsPane.tsx
@@ -35,7 +35,7 @@ const SearchResultsPane = ({
           // + card wrapper padding (2*10 = 20)
           // + border (2*1 = 2)
           // = 402:
-          minHeight: 402,
+          minHeight: '402px',
           ...BOX_SHADOW,
         }}
         loading={isFetchingData}

--- a/src/js/components/Search/SearchResultsPane.tsx
+++ b/src/js/components/Search/SearchResultsPane.tsx
@@ -29,7 +29,13 @@ const SearchResultsPane = ({
           padding: '10px 33px',
           maxWidth: '1200px',
           width: '100%',
-          minHeight: '28rem',
+          //   chart (300)
+          // + heading (24 + 8 [0.5em] bottom margin)
+          // + card body padding (2*24 = 48)
+          // + card wrapper padding (2*10 = 20)
+          // + border (2*1 = 2)
+          // = 402:
+          minHeight: 402,
           ...BOX_SHADOW,
         }}
         loading={isFetchingData}
@@ -58,7 +64,9 @@ const SearchResultsPane = ({
             </Space>
           </Col>
           <Col xs={24} lg={10}>
-            <Typography.Title level={5}>{t('Biosamples')}</Typography.Title>
+            <Typography.Title level={5} style={{ marginTop: 0 }}>
+              {t('Biosamples')}
+            </Typography.Title>
             {!hasInsufficientData && biosampleChartData.length ? (
               <PieChart data={biosampleChartData} height={PIE_CHART_HEIGHT} sort={true} />
             ) : (
@@ -66,7 +74,9 @@ const SearchResultsPane = ({
             )}
           </Col>
           <Col xs={24} lg={10}>
-            <Typography.Title level={5}>{t('Experiments')}</Typography.Title>
+            <Typography.Title level={5} style={{ marginTop: 0 }}>
+              {t('Experiments')}
+            </Typography.Title>
             {!hasInsufficientData && experimentChartData.length ? (
               <PieChart data={experimentChartData} height={PIE_CHART_HEIGHT} sort={true} />
             ) : (


### PR DESCRIPTION
also reduces minimum height to what is necessary.