### PR TITLE
gitignore core dump files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ www/
 
 .yalc
 yalc.lock
+
+core


### PR DESCRIPTION
Remove dev headache: builds can crash during development, which produces a very large `core` file. This doesn't need to be tracked, and is large enough that it doesn't play nicely with VS Code's git UI. 
