### PR TITLE
chore: remove unused code for iframed Bento Public

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -17,17 +17,6 @@
 
     <body>
         <div id="root"></div>
-        <script>
-            // for Bento-Public embedded iframes:
-            window.addEventListener("load", function () {
-                setInterval(function () {
-                    let message = {height: document.body.scrollHeight}; // width is assumed to be 100% already
-
-                    // window.top refers to parent window
-                    window.parent.postMessage(message, "*");
-                }, 500);
-            });
-        </script>
         <%= htmlWebpackPlugin.tags.bodyTags %>
     </body>
 </html>


### PR DESCRIPTION
I think this was some experiment for use in a BQC19 website iframe attempt, but to my knowledge this isn't used anywhere (confirmed with David B). 