### PR TITLE
fix: missing entrypoint in dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,6 @@ COPY LICENSE .
 COPY create_config_prod.js .
 # - Copy in the service info generator
 COPY create_service_info.js .
-# - Copy the entrypoint.bash, which sets the user and permissions
-COPY entrypoint.bash .
 # - Copy in the run.bash, which writes the config file and starts NGINX
 COPY run.bash .
 # - Copy in package.json to provide version to scripts
@@ -59,5 +57,4 @@ COPY package.json .
 #    - this way we can cache layers
 COPY --from=build /bento-public/dist ./dist
 
-ENTRYPOINT [ "/bin/bash", "./entrypoint.bash" ]
 CMD [ "/bin/bash", "./run.bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,9 @@ COPY LICENSE .
 COPY create_config_prod.js .
 # - Copy in the service info generator
 COPY create_service_info.js .
-# - Copy in the entrypoint, which writes the config file and starts NGINX
+# - Copy the entrypoint.bash, which sets the user and permissions
+COPY entrypoint.bash .
+# - Copy in the run.bash, which writes the config file and starts NGINX
 COPY run.bash .
 # - Copy in package.json to provide version to scripts
 COPY package.json .

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -13,6 +13,7 @@ LABEL org.opencontainers.image.description="Local development image for Bento Pu
 
 WORKDIR /bento-public
 
+COPY entrypoint.bash .
 COPY run.dev.bash .
 COPY package.json .
 COPY package-lock.json .


### PR DESCRIPTION
Currently, containers created from `bento_public@edge` fail at start time due to missing `entrypoint.bash` file in the image.