### PR TITLE
Added onclick pointer to bar chart/histogram

### DIFF
--- a/src/js/components/Overview/Chart.tsx
+++ b/src/js/components/Overview/Chart.tsx
@@ -9,6 +9,7 @@ import { useTranslationFn } from '@/hooks';
 import type { ChartData } from '@/types/data';
 import type { ChartConfig } from '@/types/chartConfig';
 import { CHART_TYPE_BAR, CHART_TYPE_CHOROPLETH, CHART_TYPE_HISTOGRAM, CHART_TYPE_PIE } from '@/types/chartConfig';
+import { noop } from '@/utils/chart';
 
 interface BarChartEvent {
   activePayload: Array<{ payload: { x: string; id?: string } }>;
@@ -48,7 +49,7 @@ const Chart = memo(({ chartConfig, data, units, id, isClickable }: ChartProps) =
           units={units}
           preFilter={removeMissing}
           dataMap={translateMap}
-          {...(isClickable ? { onChartClick: barChartOnChartClickHandler } : {})}
+          {...(isClickable ? { onChartClick: barChartOnChartClickHandler, onClick: noop } : {})}
         />
       );
     case CHART_TYPE_HISTOGRAM:
@@ -59,7 +60,7 @@ const Chart = memo(({ chartConfig, data, units, id, isClickable }: ChartProps) =
           data={data}
           preFilter={removeMissing}
           dataMap={translateMap}
-          {...(isClickable ? { onChartClick: barChartOnChartClickHandler } : {})}
+          {...(isClickable ? { onChartClick: barChartOnChartClickHandler, onClick: noop } : {})}
         />
       );
     case CHART_TYPE_PIE:

--- a/src/js/utils/chart.ts
+++ b/src/js/utils/chart.ts
@@ -4,3 +4,5 @@ import type { ChartData } from '@/types/data';
 export const serializeChartData = (chartData: Datum[]): ChartData[] => {
   return chartData.map(({ label, value }) => ({ x: label, y: value }));
 };
+
+export const noop = () => {};


### PR DESCRIPTION
This was removed when onClick started to work with on click on the possible render area for a bar as it caused multiple complications. Now it added back but only for bars even though you are allowed to click around it also.