### PR TITLE
fix: config/overview sometimes not re-fetched on scope change

### DIFF
--- a/src/js/components/BentoAppRouter.tsx
+++ b/src/js/components/BentoAppRouter.tsx
@@ -109,6 +109,7 @@ const BentoAppRouter = () => {
 
     // If scope or authorization status changed, invalidate anything which is scope/authz-contextual and uses a
     // lazy-loading-style hook for data fetching:
+    console.debug('isAuthenticated | scope | scopeSet changed - dispatching config/data invalidate actions');
     dispatch(invalidateConfig());
     dispatch(invalidateData());
   }, [dispatch, isAuthenticated, scope, scopeSet]);

--- a/src/js/features/config/hooks.ts
+++ b/src/js/features/config/hooks.ts
@@ -14,6 +14,7 @@ export const useConfig = () => {
   //  - config was invalidated (scope or authorization changed)
   useEffect(() => {
     if (scopeSet) {
+      // dispatch action if scope is set and/or the state is invalidated and then this hook is called.
       dispatch(makeGetConfigRequest());
     }
   }, [dispatch, scopeSet, configIsInvalid]);

--- a/src/js/features/config/hooks.ts
+++ b/src/js/features/config/hooks.ts
@@ -1,25 +1,22 @@
 import { useEffect } from 'react';
-import { useIsAuthenticated } from 'bento-auth-js';
 import { useAppDispatch, useAppSelector } from '@/hooks';
 import { makeGetConfigRequest } from '@/features/config/config.store';
 import { useSelectedScope } from '@/features/metadata/hooks';
 
 export const useConfig = () => {
   const dispatch = useAppDispatch();
-
-  const isAuthenticated = useIsAuthenticated();
-  const { scope, scopeSet } = useSelectedScope();
+  const { scopeSet } = useSelectedScope();
+  const { configStatus, configIsInvalid, countThreshold, maxQueryParameters, maxQueryParametersRequired } =
+    useAppSelector((state) => state.config);
 
   // Conditions where we need to reload "config" (which really is closer to rules for search):
-  //  - authorization status changed
-  //  - scope changed/was loaded from URL (scopeSet)
+  //  - scope was set (need to load for the first time)
+  //  - config was invalidated (scope or authorization changed)
   useEffect(() => {
-    dispatch(makeGetConfigRequest());
-  }, [dispatch, isAuthenticated, scope, scopeSet]);
+    if (scopeSet) {
+      dispatch(makeGetConfigRequest());
+    }
+  }, [dispatch, scopeSet, configIsInvalid]);
 
-  const { configStatus, countThreshold, maxQueryParameters, maxQueryParametersRequired } = useAppSelector(
-    (state) => state.config
-  );
-
-  return { configStatus, countThreshold, maxQueryParameters, maxQueryParametersRequired };
+  return { configStatus, configIsInvalid, countThreshold, maxQueryParameters, maxQueryParametersRequired };
 };

--- a/src/js/features/data/hooks.ts
+++ b/src/js/features/data/hooks.ts
@@ -1,5 +1,4 @@
 import { useEffect, useMemo } from 'react';
-import { useIsAuthenticated } from 'bento-auth-js';
 import { useSelectedScope } from '@/features/metadata/hooks';
 import { useSearchQuery } from '@/features/search/hooks';
 import { useAppDispatch, useAppSelector } from '@/hooks';
@@ -8,12 +7,7 @@ import { makeGetDataRequestThunk } from './makeGetDataRequest.thunk';
 
 export const useData = () => {
   const dispatch = useAppDispatch();
-
-  // Begin data refresh trigger dependencies
-  const isAuthenticated = useIsAuthenticated();
-  const { scope, scopeSet } = useSelectedScope();
-  // End data refresh trigger dependencies
-
+  const { scopeSet } = useSelectedScope();
   const state = useAppSelector((state) => state.data);
 
   useEffect(() => {
@@ -22,7 +16,7 @@ export const useData = () => {
       // In this way we can avoid making needless fetches up front.
       dispatch(makeGetDataRequestThunk());
     }
-  }, [dispatch, isAuthenticated, scope, scopeSet]);
+  }, [dispatch, scopeSet, state.isInvalid]);
 
   return state;
 };

--- a/src/js/features/data/hooks.ts
+++ b/src/js/features/data/hooks.ts
@@ -12,8 +12,7 @@ export const useData = () => {
 
   useEffect(() => {
     if (scopeSet) {
-      // Parameter to turn off data fetching in some circumstances, e.g., if the data catalogue is being shown.
-      // In this way we can avoid making needless fetches up front.
+      // dispatch action if scope is set and/or the state is invalidated and then this hook is called.
       dispatch(makeGetDataRequestThunk());
     }
   }, [dispatch, scopeSet, state.isInvalid]);

--- a/src/js/features/data/makeGetDataRequest.thunk.ts
+++ b/src/js/features/data/makeGetDataRequest.thunk.ts
@@ -77,7 +77,13 @@ export const makeGetDataRequestThunk = createAsyncThunk<
       const {
         data: { status, isInvalid },
       } = getState();
-      return status !== RequestStatus.Pending && (status === RequestStatus.Idle || isInvalid);
+      const cond = status !== RequestStatus.Pending && (status === RequestStatus.Idle || isInvalid);
+      if (!cond) {
+        console.debug(
+          `makeGetDataRequestThunk() was attempted, but will not dispatch: status=${status}, isInvalid=${isInvalid}`
+        );
+      }
+      return cond;
     },
   }
 );


### PR DESCRIPTION
some issues with hook dependencies meant when a dataset without data was selected from a project card entry, for example, the overview would not refresh. this should fix the issue.