### PR TITLE
Ignore scope in beacon network

### DIFF
--- a/src/js/components/Beacon/BeaconCommon/BeaconQueryFormUi.tsx
+++ b/src/js/components/Beacon/BeaconCommon/BeaconQueryFormUi.tsx
@@ -76,7 +76,7 @@ const BeaconQueryFormUi = ({
         query: { requestParameters: { g_variant: query }, filters: payloadFilters },
         bento: { showSummaryStatistics: true },
       };
-      if (scope.dataset) {
+      if (scope.dataset && !isNetworkQuery) {
         payload['query']['datasets'] = { datasetIds: [scope.dataset] };
       }
       return payload;


### PR DESCRIPTION
Ignore any local scope in calls to beacons in beacon network. 

Although the "Beacon Network" tab is available only at instance-wide scope, it seems like instances with a single project and dataset can have scope present in redux, which broke some assumptions about scope in the beacon code. 