### PR TITLE
Pull search options from beacon 

### DIFF
--- a/src/js/components/Beacon/BeaconCommon/BeaconQueryFormUi.tsx
+++ b/src/js/components/Beacon/BeaconCommon/BeaconQueryFormUi.tsx
@@ -16,7 +16,7 @@ import type {
   BeaconFilterSection,
   FormFilter,
   FormValues,
-  PayloadFilter,
+  BeaconPayloadFilter,
   PayloadVariantsQuery,
 } from '@/types/beacon';
 import { BOX_SHADOW } from '@/constants/overviewConstants';
@@ -70,7 +70,7 @@ const BeaconQueryFormUi = ({
   const showError = hasError && !errorAlertClosed;
 
   const requestPayload = useCallback(
-    (query: PayloadVariantsQuery, payloadFilters: PayloadFilter[]): BeaconQueryPayload => {
+    (query: PayloadVariantsQuery, payloadFilters: BeaconPayloadFilter[]): BeaconQueryPayload => {
       const payload: BeaconQueryPayload = {
         meta: { apiVersion: '2.0.0' },
         query: { requestParameters: { g_variant: query }, filters: payloadFilters },
@@ -118,7 +118,7 @@ const BeaconQueryFormUi = ({
   const convertToZeroBased = (start: string) => Number(start) - 1;
 
   const packageFilters = useCallback(
-    (values: FormValues): PayloadFilter[] => {
+    (values: FormValues): BeaconPayloadFilter[] => {
       // ignore optional first filter when left blank
       if (filters.length === 1 && !values.filterId1) {
         return [];

--- a/src/js/components/Beacon/BeaconCommon/BeaconQueryFormUi.tsx
+++ b/src/js/components/Beacon/BeaconCommon/BeaconQueryFormUi.tsx
@@ -13,6 +13,7 @@ import type {
   BeaconAssemblyIds,
   BeaconQueryPayload,
   BeaconQueryAction,
+  BeaconFilterSection,
   FormFilter,
   FormValues,
   PayloadFilter,
@@ -39,9 +40,9 @@ const BeaconQueryFormUi = ({
   isFetchingQueryResponse, //used in local beacon only
   isNetworkQuery,
   beaconAssemblyIds,
-  querySections,
   launchQuery,
   apiErrorMessage,
+  beaconFiltersBySection,
 }: BeaconQueryFormUiProps) => {
   const t = useTranslationFn();
   const [form] = Form.useForm();
@@ -272,7 +273,7 @@ const BeaconQueryFormUi = ({
                   filters={filters}
                   setFilters={setFilters}
                   form={form}
-                  querySections={querySections}
+                  beaconFiltersBySection={beaconFiltersBySection}
                   isNetworkQuery={isNetworkQuery}
                 />
               </Card>
@@ -306,9 +307,9 @@ export interface BeaconQueryFormUiProps {
   isFetchingQueryResponse: boolean;
   isNetworkQuery: boolean;
   beaconAssemblyIds: BeaconAssemblyIds;
-  querySections: Section[];
   launchQuery: BeaconQueryAction;
   apiErrorMessage?: string;
+  beaconFiltersBySection: BeaconFilterSection[]
 }
 
 export default BeaconQueryFormUi;

--- a/src/js/components/Beacon/BeaconCommon/BeaconQueryFormUi.tsx
+++ b/src/js/components/Beacon/BeaconCommon/BeaconQueryFormUi.tsx
@@ -308,7 +308,7 @@ export interface BeaconQueryFormUiProps {
   beaconAssemblyIds: BeaconAssemblyIds;
   launchQuery: BeaconQueryAction;
   apiErrorMessage?: string;
-  beaconFiltersBySection: BeaconFilterSection[]
+  beaconFiltersBySection: BeaconFilterSection[];
 }
 
 export default BeaconQueryFormUi;

--- a/src/js/components/Beacon/BeaconCommon/BeaconQueryFormUi.tsx
+++ b/src/js/components/Beacon/BeaconCommon/BeaconQueryFormUi.tsx
@@ -19,7 +19,6 @@ import type {
   PayloadFilter,
   PayloadVariantsQuery,
 } from '@/types/beacon';
-import type { Section } from '@/types/search';
 import { BOX_SHADOW } from '@/constants/overviewConstants';
 import {
   FORM_ROW_GUTTERS,

--- a/src/js/components/Beacon/BeaconCommon/Filter.tsx
+++ b/src/js/components/Beacon/BeaconCommon/Filter.tsx
@@ -12,7 +12,6 @@ import type {
   BeaconFilterSection,
   BeaconFilterForQuery,
 } from '@/types/beacon';
-import type { Section, Field } from '@/types/search';
 
 // TODOs:
 // any search key (eg "sex") selected in one filter should not available in other

--- a/src/js/components/Beacon/BeaconCommon/Filter.tsx
+++ b/src/js/components/Beacon/BeaconCommon/Filter.tsx
@@ -9,11 +9,12 @@ import type {
   FilterPullDownKey,
   FilterPullDownValue,
   GenericOptionType,
+  BeaconFilterSection,
+  BeaconFilterForQuery,
 } from '@/types/beacon';
 import type { Section, Field } from '@/types/search';
 
 // TODOs:
-// rewrite to use beacon specification filters instead of bento public "querySections"
 // any search key (eg "sex") selected in one filter should not available in other
 // for clarity they should probably appear, but be greyed out
 // this requires rendering select options as <Option> components
@@ -21,7 +22,7 @@ import type { Section, Field } from '@/types/search';
 const FILTER_FORM_ITEM_STYLE = { flex: 1, marginInlineEnd: -1 };
 const FILTER_FORM_ITEM_INNER_STYLE = { width: '100%' };
 
-const Filter = ({ filter, form, querySections, removeFilter, isRequired }: FilterProps) => {
+const Filter = ({ filter, form, beaconFiltersBySection, removeFilter, isRequired }: FilterProps) => {
   const t = useTranslationFn();
 
   const [valueOptions, setValueOptions] = useState([{ label: '', value: '' }]);
@@ -44,24 +45,25 @@ const Filter = ({ filter, form, querySections, removeFilter, isRequired }: Filte
     });
   }, [filter.index, form, valueOptions]);
 
-  const renderLabel = (searchField: Field) => {
-    const units = searchField.config?.units;
+  const renderLabel = (filter: BeaconFilterForQuery) => {
+    const units = filter.units ?? '';
     const unitsString = units ? ` (${t(units)})` : '';
-    return t(searchField.title) + unitsString;
+    return t(filter.label) + unitsString;
   };
 
-  const searchKeyOptions = (arr: Section[]): FilterOption[] => {
+  const searchKeyOptions = (arr: BeaconFilterSection[]): FilterOption[] => {
     return arr.map((qs) => ({
       label: t(qs.section_title),
       options: qs.fields.map((field) => ({
         label: renderLabel(field),
         value: field.id,
-        optionsThisKey: searchValueOptions(field.options),
+        optionsThisKey: searchValueOptions(field.values),
       })),
     }));
   };
 
-  const searchValueOptions = (arr: Field['options']): FilterPullDownValue[] => arr.map((v) => ({ label: v, value: v }));
+  const searchValueOptions = (arr: BeaconFilterForQuery['values']): FilterPullDownValue[] =>
+    arr.map((v) => ({ label: v, value: v }));
 
   return (
     <Space.Compact>
@@ -74,7 +76,7 @@ const Filter = ({ filter, form, querySections, removeFilter, isRequired }: Filte
           placeholder={t('select a search field')}
           style={FILTER_FORM_ITEM_INNER_STYLE}
           onSelect={handleSelectKey}
-          options={searchKeyOptions(querySections)}
+          options={searchKeyOptions(beaconFiltersBySection)}
         />
       </Form.Item>
       <Form.Item
@@ -97,7 +99,7 @@ const Filter = ({ filter, form, querySections, removeFilter, isRequired }: Filte
 export interface FilterProps {
   filter: FormFilter;
   form: FormInstance;
-  querySections: Section[];
+  beaconFiltersBySection: BeaconFilterSection[];
   removeFilter: (filter: FormFilter) => void;
   isRequired: boolean;
 }

--- a/src/js/components/Beacon/BeaconCommon/Filter.tsx
+++ b/src/js/components/Beacon/BeaconCommon/Filter.tsx
@@ -10,7 +10,7 @@ import type {
   FilterPullDownValue,
   GenericOptionType,
   BeaconFilterSection,
-  BeaconFilterForQuery,
+  BeaconFilterUiOptions,
 } from '@/types/beacon';
 
 // TODOs:
@@ -44,7 +44,7 @@ const Filter = ({ filter, form, beaconFiltersBySection, removeFilter, isRequired
     });
   }, [filter.index, form, valueOptions]);
 
-  const renderLabel = (filter: BeaconFilterForQuery) => {
+  const renderLabel = (filter: BeaconFilterUiOptions) => {
     const units = filter.units ?? '';
     const unitsString = units ? ` (${t(units)})` : '';
     return t(filter.label) + unitsString;
@@ -61,7 +61,7 @@ const Filter = ({ filter, form, beaconFiltersBySection, removeFilter, isRequired
     }));
   };
 
-  const searchValueOptions = (arr: BeaconFilterForQuery['values']): FilterPullDownValue[] =>
+  const searchValueOptions = (arr: BeaconFilterUiOptions['values']): FilterPullDownValue[] =>
     arr.map((v) => ({ label: v, value: v }));
 
   return (

--- a/src/js/components/Beacon/BeaconCommon/Filters.tsx
+++ b/src/js/components/Beacon/BeaconCommon/Filters.tsx
@@ -23,9 +23,7 @@ const NetworkFilterToggle = () => {
           checked={isFiltersUnion}
           style={{ margin: '5px' }}
         />
-        <p style={{ margin: '5px' }}>
-          {t(`beacon.${isFiltersUnion ? 'show_all_filters' : 'common_filters_only'}`)}
-        </p>
+        <p style={{ margin: '5px' }}>{t(`beacon.${isFiltersUnion ? 'show_all_filters' : 'common_filters_only'}`)}</p>
       </div>
     </Tooltip>
   );
@@ -92,7 +90,7 @@ export interface FiltersProps {
   filters: FormFilter[];
   setFilters: Dispatch<SetStateAction<FormFilter[]>>;
   form: FormInstance;
-  beaconFiltersBySection: BeaconFilterSection[]
+  beaconFiltersBySection: BeaconFilterSection[];
   isNetworkQuery: boolean;
 }
 

--- a/src/js/components/Beacon/BeaconCommon/Filters.tsx
+++ b/src/js/components/Beacon/BeaconCommon/Filters.tsx
@@ -7,7 +7,6 @@ import { toggleQuerySectionsUnionOrIntersection } from '@/features/beacon/networ
 import { useConfig } from '@/features/config/hooks';
 import { useAppDispatch, useTranslationFn } from '@/hooks';
 import type { BeaconFilterSection, FormFilter } from '@/types/beacon';
-import type { SearchFieldResponse } from '@/types/search';
 
 import Filter from './Filter';
 

--- a/src/js/components/Beacon/BeaconCommon/Filters.tsx
+++ b/src/js/components/Beacon/BeaconCommon/Filters.tsx
@@ -6,7 +6,7 @@ import { useBeaconNetwork } from '@/features/beacon/hooks';
 import { toggleQuerySectionsUnionOrIntersection } from '@/features/beacon/network.store';
 import { useConfig } from '@/features/config/hooks';
 import { useAppDispatch, useTranslationFn } from '@/hooks';
-import type { FormFilter } from '@/types/beacon';
+import type { BeaconFilterSection, FormFilter } from '@/types/beacon';
 import type { SearchFieldResponse } from '@/types/search';
 
 import Filter from './Filter';
@@ -14,18 +14,18 @@ import Filter from './Filter';
 const NetworkFilterToggle = () => {
   const t = useTranslationFn();
   const dispatch = useAppDispatch();
-  const { isQuerySectionsUnion } = useBeaconNetwork();
+  const { isFiltersUnion } = useBeaconNetwork();
 
   return (
     <Tooltip title={t('beacon.network_filter_toggle_help')}>
       <div style={{ display: 'flex', alignItems: 'center' }}>
         <Switch
           onChange={() => dispatch(toggleQuerySectionsUnionOrIntersection())}
-          checked={isQuerySectionsUnion}
+          checked={isFiltersUnion}
           style={{ margin: '5px' }}
         />
         <p style={{ margin: '5px' }}>
-          {t(`beacon.${isQuerySectionsUnion ? 'show_all_filters' : 'common_filters_only'}`)}
+          {t(`beacon.${isFiltersUnion ? 'show_all_filters' : 'common_filters_only'}`)}
         </p>
       </div>
     </Tooltip>
@@ -37,7 +37,7 @@ const NetworkFilterToggle = () => {
 
 const BUTTON_STYLE = { margin: '10px 0' };
 
-const Filters = ({ filters, setFilters, form, querySections, isNetworkQuery }: FiltersProps) => {
+const Filters = ({ filters, setFilters, form, beaconFiltersBySection, isNetworkQuery }: FiltersProps) => {
   const t = useTranslationFn();
 
   const { maxQueryParameters: maxFilters, maxQueryParametersRequired } = useConfig();
@@ -79,7 +79,7 @@ const Filters = ({ filters, setFilters, form, querySections, isNetworkQuery }: F
             key={f.index}
             filter={f}
             form={form}
-            querySections={querySections}
+            beaconFiltersBySection={beaconFiltersBySection}
             removeFilter={removeFilter}
             isRequired={isRequired}
           />
@@ -93,7 +93,7 @@ export interface FiltersProps {
   filters: FormFilter[];
   setFilters: Dispatch<SetStateAction<FormFilter[]>>;
   form: FormInstance;
-  querySections: SearchFieldResponse['sections'];
+  beaconFiltersBySection: BeaconFilterSection[]
   isNetworkQuery: boolean;
 }
 

--- a/src/js/components/Beacon/BeaconNetwork/NetworkUi.tsx
+++ b/src/js/components/Beacon/BeaconNetwork/NetworkUi.tsx
@@ -9,7 +9,7 @@ import NetworkBeacons from './NetworkBeacons';
 import NetworkSearchResults from './NetworkSearchResults';
 
 const NetworkUi = () => {
-  const { isFetchingBeaconNetworkConfig, assemblyIds, currentQuerySections, beaconResponses } = useBeaconNetwork();
+  const { isFetchingBeaconNetworkConfig, assemblyIds, currentFilters, beaconResponses } = useBeaconNetwork();
   const isFetchingQueryResponse = atLeastOneNetworkResponseIsPending(beaconResponses);
 
   return isFetchingBeaconNetworkConfig ? (
@@ -20,8 +20,8 @@ const NetworkUi = () => {
         isFetchingQueryResponse={isFetchingQueryResponse}
         isNetworkQuery={true}
         beaconAssemblyIds={assemblyIds}
-        querySections={currentQuerySections}
         launchQuery={beaconNetworkQuery}
+        beaconFiltersBySection={currentFilters}
       />
       <NetworkSearchResults />
       <NetworkBeacons />

--- a/src/js/components/Beacon/BeaconQueryUi.tsx
+++ b/src/js/components/Beacon/BeaconQueryUi.tsx
@@ -2,7 +2,6 @@ import Loader from '@/components/Loader';
 import { WRAPPER_STYLE } from '@/constants/beaconConstants';
 import { makeBeaconQuery } from '@/features/beacon/beacon.store';
 import { useBeacon } from '@/features/beacon/hooks';
-import { useAppSelector } from '@/hooks';
 
 import BeaconSearchResults from './BeaconSearchResults';
 import BeaconQueryFormUi from './BeaconCommon/BeaconQueryFormUi';
@@ -10,7 +9,6 @@ import BeaconQueryFormUi from './BeaconCommon/BeaconQueryFormUi';
 const BeaconQueryUi = () => {
   const { isFetchingBeaconConfig, beaconAssemblyIds, beaconFilters, isFetchingQueryResponse, apiErrorMessage } =
     useBeacon();
-  const { querySections } = useAppSelector((state) => state.query);
 
   return isFetchingBeaconConfig ? (
     <Loader />

--- a/src/js/components/Beacon/BeaconQueryUi.tsx
+++ b/src/js/components/Beacon/BeaconQueryUi.tsx
@@ -8,7 +8,8 @@ import BeaconSearchResults from './BeaconSearchResults';
 import BeaconQueryFormUi from './BeaconCommon/BeaconQueryFormUi';
 
 const BeaconQueryUi = () => {
-  const { isFetchingBeaconConfig, beaconAssemblyIds, isFetchingQueryResponse, apiErrorMessage } = useBeacon();
+  const { isFetchingBeaconConfig, beaconAssemblyIds, beaconFilters, isFetchingQueryResponse, apiErrorMessage } =
+    useBeacon();
   const { querySections } = useAppSelector((state) => state.query);
 
   return isFetchingBeaconConfig ? (
@@ -20,9 +21,9 @@ const BeaconQueryUi = () => {
         isFetchingQueryResponse={isFetchingQueryResponse}
         isNetworkQuery={false}
         beaconAssemblyIds={beaconAssemblyIds}
-        querySections={querySections}
         launchQuery={makeBeaconQuery}
         apiErrorMessage={apiErrorMessage}
+        beaconFiltersBySection={beaconFilters}
       />
     </div>
   );

--- a/src/js/components/BentoAppRouter.tsx
+++ b/src/js/components/BentoAppRouter.tsx
@@ -5,7 +5,7 @@ import { useAppDispatch } from '@/hooks';
 
 import { invalidateConfig, makeGetServiceInfoRequest } from '@/features/config/config.store';
 import { makeGetAboutRequest } from '@/features/content/content.store';
-import { getBeaconConfig } from '@/features/beacon/beacon.store';
+import { getBeaconConfig, getBeaconFilters } from '@/features/beacon/beacon.store';
 import { getBeaconNetworkConfig } from '@/features/beacon/network.store';
 import { fetchGohanData, fetchKatsuData } from '@/features/ingestion/lastIngestion.store';
 import { invalidateData } from '@/features/data/data.store';
@@ -17,7 +17,7 @@ import { makeGetKatsuPublic, makeGetSearchFields } from '@/features/search/query
 
 import Loader from '@/components/Loader';
 import DefaultLayout from '@/components/Util/DefaultLayout';
-import { BEACON_NETWORK_ENABLED } from '@/config';
+import { BEACON_UI_ENABLED, BEACON_NETWORK_ENABLED } from '@/config';
 import { WAITING_STATES } from '@/constants/requests';
 import { RequestStatus } from '@/types/requests';
 import { BentoRoute } from '@/types/routes';
@@ -102,10 +102,14 @@ const BentoAppRouter = () => {
 
   useEffect(() => {
     if (!scopeSet) return;
-    dispatch(getBeaconConfig());
     dispatch(makeGetSearchFields());
     dispatch(makeGetKatsuPublic());
     dispatch(fetchKatsuData());
+
+    if (BEACON_UI_ENABLED) {
+      dispatch(getBeaconConfig());
+      dispatch(getBeaconFilters());
+    }
 
     // If scope or authorization status changed, invalidate anything which is scope/authz-contextual and uses a
     // lazy-loading-style hook for data fetching:

--- a/src/js/features/beacon/beacon.store.ts
+++ b/src/js/features/beacon/beacon.store.ts
@@ -48,7 +48,6 @@ export const getBeaconFilters = createAsyncThunk<
 >(
   'beacon/getBeaconFilters',
   (_, { getState, rejectWithValue }) => {
-    const token = getState().auth.accessToken;
     const projectId = getState().metadata.selectedScope.scope.project;
     const datasetId = getState().metadata.selectedScope.scope.dataset;
 
@@ -69,9 +68,7 @@ export const makeBeaconQuery = createAsyncThunk<
   BeaconQueryPayload,
   { state: RootState; rejectValue: string }
 >('beacon/makeBeaconQuery', async (payload, { getState, rejectWithValue }) => {
-  const token = getState().auth.accessToken;
   const projectId = getState().metadata.selectedScope.scope.project;
-  const headers = makeAuthorizationHeader(token);
   return axios
     .post(scopedBeaconIndividualsUrl(projectId), payload, authorizedRequestConfig(getState()))
     .then((res) => res.data)

--- a/src/js/features/beacon/beacon.store.ts
+++ b/src/js/features/beacon/beacon.store.ts
@@ -58,7 +58,7 @@ export const getBeaconFilters = createAsyncThunk<
   },
   {
     condition(_, { getState }) {
-      return getState().metadata.selectedScope.scopeSet && getState().beacon.filtersStatus === RequestStatus.Idle;
+      return getState().metadata.selectedScope.scopeSet && getState().beacon.filtersStatus !== RequestStatus.Pending;
     },
   }
 );

--- a/src/js/features/beacon/beacon.store.ts
+++ b/src/js/features/beacon/beacon.store.ts
@@ -1,6 +1,5 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios';
-import { makeAuthorizationHeader } from 'bento-auth-js';
 import { authorizedRequestConfig } from '@/utils/requests';
 
 import { EMPTY_DISCOVERY_RESULTS } from '@/constants/searchConstants';

--- a/src/js/features/beacon/beacon.store.ts
+++ b/src/js/features/beacon/beacon.store.ts
@@ -1,6 +1,7 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios';
 import { makeAuthorizationHeader } from 'bento-auth-js';
+import { authorizedRequestConfig } from '@/utils/requests';
 
 import { EMPTY_DISCOVERY_RESULTS } from '@/constants/searchConstants';
 import { BEACON_INFO_ENDPOINT } from '@/features/beacon/constants';
@@ -50,16 +51,15 @@ export const getBeaconFilters = createAsyncThunk<
     const token = getState().auth.accessToken;
     const projectId = getState().metadata.selectedScope.scope.project;
     const datasetId = getState().metadata.selectedScope.scope.dataset;
-    const headers = makeAuthorizationHeader(token);
 
     return axios
-      .get(scopedBeaconFilteringTermsUrl(projectId, datasetId), { headers: headers as Record<string, string> })
+      .get(scopedBeaconFilteringTermsUrl(projectId, datasetId), authorizedRequestConfig(getState()))
       .then((res) => res.data)
       .catch(printAPIError(rejectWithValue));
   },
   {
     condition(_, { getState }) {
-      return getState().metadata.selectedScope.scopeSet;
+      return getState().metadata.selectedScope.scopeSet && !getState().beacon.isFetchingFilters;
     },
   }
 );
@@ -73,7 +73,7 @@ export const makeBeaconQuery = createAsyncThunk<
   const projectId = getState().metadata.selectedScope.scope.project;
   const headers = makeAuthorizationHeader(token);
   return axios
-    .post(scopedBeaconIndividualsUrl(projectId), payload, { headers: headers as Record<string, string> })
+    .post(scopedBeaconIndividualsUrl(projectId), payload, authorizedRequestConfig(getState()))
     .then((res) => res.data)
     .catch(beaconApiError(rejectWithValue));
 });

--- a/src/js/features/beacon/beacon.store.ts
+++ b/src/js/features/beacon/beacon.store.ts
@@ -48,11 +48,9 @@ export const getBeaconFilters = createAsyncThunk<
 >(
   'beacon/getBeaconFilters',
   (_, { getState, rejectWithValue }) => {
-    const projectId = getState().metadata.selectedScope.scope.project;
-    const datasetId = getState().metadata.selectedScope.scope.dataset;
-
+    const { project, dataset } = getState().metadata.selectedScope.scope;
     return axios
-      .get(scopedBeaconFilteringTermsUrl(projectId, datasetId), authorizedRequestConfig(getState()))
+      .get(scopedBeaconFilteringTermsUrl(project, dataset), authorizedRequestConfig(getState()))
       .then((res) => res.data)
       .catch(printAPIError(rejectWithValue));
   },

--- a/src/js/features/beacon/constants.ts
+++ b/src/js/features/beacon/constants.ts
@@ -1,6 +1,8 @@
 import { BEACON_URL } from '@/config';
 
 export const BEACON_INDIVIDUALS_PATH = '/individuals';
+export const BEACON_FILTERING_TERMS_PATH = '/filtering_terms';
+export const BEACON_OVERVIEW_PATH = '/overview'
 
+// add scope.. currently node-level only but will change without notice
 export const BEACON_INFO_ENDPOINT = BEACON_URL + '/overview';
-export const BEACON_INDIVIDUALS_ENDPOINT = BEACON_URL + BEACON_INDIVIDUALS_PATH;

--- a/src/js/features/beacon/constants.ts
+++ b/src/js/features/beacon/constants.ts
@@ -2,7 +2,7 @@ import { BEACON_URL } from '@/config';
 
 export const BEACON_INDIVIDUALS_PATH = '/individuals';
 export const BEACON_FILTERING_TERMS_PATH = '/filtering_terms';
-export const BEACON_OVERVIEW_PATH = '/overview'
+export const BEACON_OVERVIEW_PATH = '/overview';
 
 // add scope.. currently node-level only but will change without notice
 export const BEACON_INFO_ENDPOINT = BEACON_URL + '/overview';

--- a/src/js/features/beacon/utils.ts
+++ b/src/js/features/beacon/utils.ts
@@ -8,6 +8,7 @@ import type {
   BeaconQueryResponse,
   BeaconFilterSection,
 } from '@/types/beacon';
+import type { Field, Section } from '@/types/search';
 import type { ChartData, DiscoveryResults, OptionalDiscoveryResults } from '@/types/data';
 import type { NetworkBeacon } from '@/types/beaconNetwork';
 import type { Dataset, Project } from '@/types/metadata';
@@ -107,10 +108,9 @@ export const scopedBeaconFilteringTermsUrl = (
   return scopedBeaconBaseUrl(projectId) + BEACON_FILTERING_TERMS_PATH + datasetIdParam;
 };
 
-// rewrite with scopedBeaconBaseUrl
 export const scopedBeaconIndividualsUrl = (projectId: Project['identifier'] | undefined): string => {
   const projectPath: string = projectId ? '/' + projectId : '';
-  return BEACON_URL + projectPath + BEACON_INDIVIDUALS_PATH;
+  return scopedBeaconBaseUrl(projectId) + BEACON_INDIVIDUALS_PATH;
 };
 
 export const scopedBeaconOverviewUrl = (projectId: Project['identifier'] | undefined): string => {
@@ -127,4 +127,26 @@ export const packageBeaconFilteringTerms = (filters: BeaconFilteringTermFromResp
   });
   // then return as an array of categories
   return Object.keys(tempFiltersObj).map((key) => ({ section_title: key, fields: tempFiltersObj[key] }));
+};
+
+// temp repackaging of network filters from katsu format to beacon filters format
+// can be removed once network stops calling katsu 
+export const packageBeaconNetworkQuerySections = (qs: Section[]) => {
+  return qs.map((q) => ({
+    ...q,
+    fields: q.fields.map((f: Field) => {
+      const filter: BeaconFilterForQuery = {
+        type: 'alphanumeric',
+        id: f.id,
+        label: f.title,
+        description: f.description,
+        values: f.options,
+      };
+      const units = f.config?.units;
+      if (units) {
+        filter.units = units;
+      }
+      return filter;
+    }),
+  }));
 };

--- a/src/js/features/beacon/utils.ts
+++ b/src/js/features/beacon/utils.ts
@@ -109,7 +109,6 @@ export const scopedBeaconFilteringTermsUrl = (
 };
 
 export const scopedBeaconIndividualsUrl = (projectId: Project['identifier'] | undefined): string => {
-  const projectPath: string = projectId ? '/' + projectId : '';
   return scopedBeaconBaseUrl(projectId) + BEACON_INDIVIDUALS_PATH;
 };
 
@@ -130,7 +129,7 @@ export const packageBeaconFilteringTerms = (filters: BeaconFilteringTermFromResp
 };
 
 // temp repackaging of network filters from katsu format to beacon filters format
-// can be removed once network stops calling katsu 
+// can be removed once network stops calling katsu
 export const packageBeaconNetworkQuerySections = (qs: Section[]) => {
   return qs.map((q) => ({
     ...q,

--- a/src/js/features/beacon/utils.ts
+++ b/src/js/features/beacon/utils.ts
@@ -2,8 +2,8 @@ import { BEACON_URL, BEACON_NETWORK_URL } from '@/config';
 import { BEACON_INDIVIDUALS_PATH, BEACON_FILTERING_TERMS_PATH, BEACON_OVERVIEW_PATH } from './constants';
 import type {
   BeaconAssemblyIds,
-  BeaconFilteringTermFromResponse,
-  BeaconFilterForQuery,
+  BeaconFilteringTermFromEndpoint,
+  BeaconFilterUiOptions,
   BeaconNetworkResponses,
   BeaconQueryResponse,
   BeaconFilterSection,
@@ -117,9 +117,9 @@ export const scopedBeaconOverviewUrl = (projectId: Project['identifier'] | undef
 };
 
 // package flat beacon filtering terms array into an array of categories (similar to katsu query params)
-export const packageBeaconFilteringTerms = (filters: BeaconFilteringTermFromResponse[]): BeaconFilterSection[] => {
+export const packageBeaconFilteringTerms = (filters: BeaconFilteringTermFromEndpoint[]): BeaconFilterSection[] => {
   // temp object to simplify merging fields by category
-  const tempFiltersObj: Record<string, BeaconFilterForQuery[]> = {};
+  const tempFiltersObj: Record<string, BeaconFilterUiOptions[]> = {};
   filters.forEach((f) => {
     const { bento, ...filter_details } = f;
     tempFiltersObj[bento.section] = (tempFiltersObj[bento.section] ?? []).concat(filter_details);
@@ -134,7 +134,7 @@ export const packageBeaconNetworkQuerySections = (qs: Section[]) => {
   return qs.map((q) => ({
     ...q,
     fields: q.fields.map((f: Field) => {
-      const filter: BeaconFilterForQuery = {
+      const filter: BeaconFilterUiOptions = {
         type: 'alphanumeric',
         id: f.id,
         label: f.title,

--- a/src/js/features/beacon/utils.ts
+++ b/src/js/features/beacon/utils.ts
@@ -1,9 +1,16 @@
 import { BEACON_URL, BEACON_NETWORK_URL } from '@/config';
-import { BEACON_INDIVIDUALS_PATH } from './constants';
-import type { BeaconAssemblyIds, BeaconNetworkResponses, BeaconQueryResponse } from '@/types/beacon';
+import { BEACON_INDIVIDUALS_PATH, BEACON_FILTERING_TERMS_PATH, BEACON_OVERVIEW_PATH } from './constants';
+import type {
+  BeaconAssemblyIds,
+  BeaconFilteringTermFromResponse,
+  BeaconFilterForQuery,
+  BeaconNetworkResponses,
+  BeaconQueryResponse,
+  BeaconFilterSection,
+} from '@/types/beacon';
 import type { ChartData, DiscoveryResults, OptionalDiscoveryResults } from '@/types/data';
 import type { NetworkBeacon } from '@/types/beaconNetwork';
-import type { Project } from '@/types/metadata';
+import type { Dataset, Project } from '@/types/metadata';
 import { serializeChartData } from '@/utils/chart';
 
 type TempChartObject = Record<string, number>;
@@ -87,7 +94,37 @@ export const extractBeaconDiscoveryOverview = (response: BeaconQueryResponse): O
 export const atLeastOneNetworkResponseIsPending = (responses: BeaconNetworkResponses) =>
   Object.values(responses).some((r) => r.isFetchingQueryResponse);
 
+const scopedBeaconBaseUrl = (projectId: Project['identifier'] | undefined): string => {
+  const projectPath = projectId ? '/' + projectId : '';
+  return BEACON_URL + projectPath;
+};
+
+export const scopedBeaconFilteringTermsUrl = (
+  projectId: Project['identifier'] | undefined,
+  datasetId: Dataset['identifier'] | undefined
+): string => {
+  const datasetIdParam = datasetId ? '?' + 'datasetIds=' + datasetId : '';
+  return scopedBeaconBaseUrl(projectId) + BEACON_FILTERING_TERMS_PATH + datasetIdParam;
+};
+
+// rewrite with scopedBeaconBaseUrl
 export const scopedBeaconIndividualsUrl = (projectId: Project['identifier'] | undefined): string => {
   const projectPath: string = projectId ? '/' + projectId : '';
   return BEACON_URL + projectPath + BEACON_INDIVIDUALS_PATH;
+};
+
+export const scopedBeaconOverviewUrl = (projectId: Project['identifier'] | undefined): string => {
+  return scopedBeaconBaseUrl(projectId) + BEACON_OVERVIEW_PATH;
+};
+
+// package flat beacon filtering terms array into an array of categories (similar to katsu query params)
+export const packageBeaconFilteringTerms = (filters: BeaconFilteringTermFromResponse[]): BeaconFilterSection[] => {
+  // temp object to simplify merging fields by category
+  const tempFiltersObj: Record<string, BeaconFilterForQuery[]> = {};
+  filters.forEach((f) => {
+    const { bento, ...filter_details } = f;
+    tempFiltersObj[bento.section] = (tempFiltersObj[bento.section] ?? []).concat(filter_details);
+  });
+  // then return as an array of categories
+  return Object.keys(tempFiltersObj).map((key) => ({ section_title: key, fields: tempFiltersObj[key] }));
 };

--- a/src/js/types/beacon.ts
+++ b/src/js/types/beacon.ts
@@ -179,12 +179,13 @@ export interface BeaconFilteringTermsResponse {
 export interface BeaconFilteringTermFromResponse {
   type: 'alphanumeric';
   id: string; // something more here?
-  name: string;
+  label: string;
   description: string;
   values: string[];
   bento: {
     section: string;
   };
+  units?: string;
 }
 
 export type BeaconFilterForQuery = Omit<BeaconFilteringTermFromResponse, 'bento'>;

--- a/src/js/types/beacon.ts
+++ b/src/js/types/beacon.ts
@@ -163,6 +163,38 @@ export interface BeaconServiceInfo {
 }
 
 // ----------------------------
+// filters
+// ----------------------------
+
+// https://docs.genomebeacons.org/filters/
+export interface BeaconFilteringTermsResponse {
+  meta?: {
+    beaconId: string;
+  };
+  response?: {
+    filteringTerms: BeaconFilteringTermFromResponse[];
+  };
+}
+
+export interface BeaconFilteringTermFromResponse {
+  type: 'alphanumeric';
+  id: string; // something more here?
+  name: string;
+  description: string;
+  values: string[];
+  bento: {
+    section: string;
+  };
+}
+
+export type BeaconFilterForQuery = Omit<BeaconFilteringTermFromResponse, 'bento'>;
+
+export interface BeaconFilterSection {
+  section_title: BeaconFilteringTermFromResponse['bento']['section'];
+  fields: BeaconFilterForQuery[];
+}
+
+// ----------------------------
 // response packaging
 // ----------------------------
 

--- a/src/js/types/beacon.ts
+++ b/src/js/types/beacon.ts
@@ -191,7 +191,7 @@ export interface BeaconFilteringTermFromResponse {
 export type BeaconFilterForQuery = Omit<BeaconFilteringTermFromResponse, 'bento'>;
 
 export interface BeaconFilterSection {
-  section_title: BeaconFilteringTermFromResponse['bento']['section'];
+  section_title: string;
   fields: BeaconFilterForQuery[];
 }
 

--- a/src/js/types/beacon.ts
+++ b/src/js/types/beacon.ts
@@ -178,7 +178,7 @@ export interface BeaconFilteringTermsResponse {
 
 export interface BeaconFilteringTermFromResponse {
   type: 'alphanumeric';
-  id: string; // something more here?
+  id: string;
   label: string;
   description: string;
   values: string[];

--- a/src/js/types/beacon.ts
+++ b/src/js/types/beacon.ts
@@ -49,7 +49,7 @@ export type GenericOptionType = FilterOption | FilterPullDownKey;
 // API request
 // ----------------------------
 
-export interface PayloadFilter {
+export interface BeaconPayloadFilter {
   id: string;
   value: string;
 
@@ -75,7 +75,7 @@ export interface BeaconQueryPayload {
   meta: { apiVersion: string };
   query: {
     requestParameters: { g_variant: PayloadVariantsQuery };
-    filters: PayloadFilter[];
+    filters: BeaconPayloadFilter[];
     datasets?: { datasetIds: [Dataset['identifier']] };
   };
   bento?: { showSummaryStatistics: boolean };
@@ -172,11 +172,11 @@ export interface BeaconFilteringTermsResponse {
     beaconId: string;
   };
   response?: {
-    filteringTerms: BeaconFilteringTermFromResponse[];
+    filteringTerms: BeaconFilteringTermFromEndpoint[];
   };
 }
 
-export interface BeaconFilteringTermFromResponse {
+export interface BeaconFilteringTermFromEndpoint {
   type: 'alphanumeric';
   id: string;
   label: string;
@@ -188,11 +188,11 @@ export interface BeaconFilteringTermFromResponse {
   units?: string;
 }
 
-export type BeaconFilterForQuery = Omit<BeaconFilteringTermFromResponse, 'bento'>;
+export type BeaconFilterUiOptions = Omit<BeaconFilteringTermFromEndpoint, 'bento'>;
 
 export interface BeaconFilterSection {
   section_title: string;
-  fields: BeaconFilterForQuery[];
+  fields: BeaconFilterUiOptions[];
 }
 
 // ----------------------------


### PR DESCRIPTION
Previously, the beacon tab in bento public has used the same discovery config settings as the Search tab to set metadata search options. Since Bento 18, beacon now knows its own search options, so these can be pulled from the beacon endpoint `/filtering_terms` instead. 

- makes Beacon more self-contained and closer to its intended use: 
  - it's now beacon's job to call katsu to figure out what the search options are, rather than leaving this to the web client
  - leaves open the possibility of filters that apply to other services (eg Takuan)
  - ideally the beacon UI should only need to communicate with beacon
- leaves open the possibility of working with non-Bento beacons

... and in general relying more on beacon `/filtering_terms` instead of direct calls to katsu will simplify the operation of the beacon network.


Also:
- made beacon config call conditional (it should have always been conditional)
- remapped some fields in beacon network filters (since they still follow "querySections" syntax)

