### PR TITLE
Fix/beacon filter bug

### DIFF
--- a/src/js/components/Beacon/BeaconCommon/BeaconQueryFormUi.tsx
+++ b/src/js/components/Beacon/BeaconCommon/BeaconQueryFormUi.tsx
@@ -132,7 +132,7 @@ const BeaconQueryFormUi = ({
         value: values[`filterValue${f.index}`],
       }));
     },
-    [filters]
+    [filters, filtersDirty]
   );
 
   const packageBeaconJSON = useCallback(

--- a/src/js/components/Beacon/BeaconCommon/BeaconQueryFormUi.tsx
+++ b/src/js/components/Beacon/BeaconCommon/BeaconQueryFormUi.tsx
@@ -117,10 +117,12 @@ const BeaconQueryFormUi = ({
   // see e.g., https://genome-blog.soe.ucsc.edu/blog/2016/12/12/the-ucsc-genome-browser-coordinate-counting-systems/
   const convertToZeroBased = (start: string) => Number(start) - 1;
 
+  const filtersDirty = !(filters.length === 1 && filters[0].index == 0 && filters[0].searchFieldId === null);
+
   const packageFilters = useCallback(
     (values: FormValues): BeaconPayloadFilter[] => {
       // ignore optional first filter when left blank
-      if (filters.length === 1 && !values.filterIndex1) {
+      if (!filtersDirty) {
         return [];
       }
 
@@ -269,6 +271,7 @@ const BeaconQueryFormUi = ({
                 <Filters
                   filters={filters}
                   setFilters={setFilters}
+                  filtersDirty={filtersDirty}
                   form={form}
                   beaconFiltersBySection={beaconFiltersBySection}
                   isNetworkQuery={isNetworkQuery}

--- a/src/js/components/Beacon/BeaconCommon/Filters.tsx
+++ b/src/js/components/Beacon/BeaconCommon/Filters.tsx
@@ -65,8 +65,6 @@ const Filters = ({ filters, setFilters, filtersDirty, form, beaconFiltersBySecti
 
   const searchFieldInUse = (searchFieldId: string) => filters.some((f) => f.searchFieldId === searchFieldId);
 
-  console.log({ filters });
-
   return (
     <Form.Item>
       <Space style={{ display: 'flex', padding: 0 }}>

--- a/src/js/components/Beacon/BeaconCommon/Filters.tsx
+++ b/src/js/components/Beacon/BeaconCommon/Filters.tsx
@@ -31,7 +31,7 @@ const NetworkFilterToggle = () => {
 
 const BUTTON_STYLE = { margin: '10px 0' };
 
-const Filters = ({ filters, setFilters, form, beaconFiltersBySection, isNetworkQuery }: FiltersProps) => {
+const Filters = ({ filters, setFilters, filtersDirty, form, beaconFiltersBySection, isNetworkQuery }: FiltersProps) => {
   const t = useTranslationFn();
   const [filterIndex, setFilterIndex] = useState<number>(1);
 
@@ -40,9 +40,6 @@ const Filters = ({ filters, setFilters, form, beaconFiltersBySection, isNetworkQ
 
   // don't need to pull filters from state
   // we only need to know *which* state we are in, so it can be shown in the switch
-
-  // UI starts with an optional filter, which can be left blank
-  const isRequired = filters.length > 1;
 
   const newFilter = () => {
     const filter = { index: filterIndex, searchFieldId: null };
@@ -68,6 +65,8 @@ const Filters = ({ filters, setFilters, form, beaconFiltersBySection, isNetworkQ
 
   const searchFieldInUse = (searchFieldId: string) => filters.some((f) => f.searchFieldId === searchFieldId);
 
+  console.log({ filters });
+
   return (
     <Form.Item>
       <Space style={{ display: 'flex', padding: 0 }}>
@@ -88,7 +87,7 @@ const Filters = ({ filters, setFilters, form, beaconFiltersBySection, isNetworkQ
             removeFilter={removeFilter}
             setFilterSearchFieldId={setFilterSearchFieldId}
             searchFieldInUse={searchFieldInUse}
-            isRequired={isRequired}
+            isRequired={filtersDirty}
           />
         ))}
       </div>
@@ -99,6 +98,7 @@ const Filters = ({ filters, setFilters, form, beaconFiltersBySection, isNetworkQ
 export interface FiltersProps {
   filters: FormFilter[];
   setFilters: Dispatch<SetStateAction<FormFilter[]>>;
+  filtersDirty: boolean;
   form: FormInstance;
   beaconFiltersBySection: BeaconFilterSection[];
   isNetworkQuery: boolean;


### PR DESCRIPTION
Bugfix for beacon filter handling:
- first filter was always ignored even if filled in
- previous logic for checking if you'd interacted with filters no longer applied

... let me know if I need `useCallback` here.


In the longer term we could probably replace this with the search component from the new UI, but I might wait for that to be merged first. 