### PR TITLE
deprecate old beacon overview response format

### DIFF
--- a/src/js/features/beacon/beacon.store.ts
+++ b/src/js/features/beacon/beacon.store.ts
@@ -114,7 +114,7 @@ const beacon = createSlice({
     });
     builder.addCase(getBeaconConfig.fulfilled, (state, { payload }) => {
       state.configStatus = RequestStatus.Fulfilled;
-      state.beaconAssemblyIds = Object.keys(payload.response?.overview?.counts?.variants ?? []);
+      state.beaconAssemblyIds = Object.keys(payload.response?.overview?.variants ?? []);
     });
     builder.addCase(getBeaconConfig.rejected, (state) => {
       state.configStatus = RequestStatus.Rejected;

--- a/src/js/types/beacon.ts
+++ b/src/js/types/beacon.ts
@@ -100,11 +100,8 @@ type GenericInfoField = Record<string, unknown>;
 export interface BeaconConfigResponse {
   response?: {
     overview?: {
-      counts?: {
-        // individuals: number;
-        variants?: {
-          [key: string]: string;
-        };
+      variants: {
+        [key: string]: string;
       };
     };
   };


### PR DESCRIPTION
Deprecate old beacon overview response format. (Redmine #2541)

Beacon currently sends old and new formats together, so this is non-breaking. 