### PR TITLE
Beacon uncensored zeros

### DIFF
--- a/src/js/components/Beacon/BeaconSearchResults.tsx
+++ b/src/js/components/Beacon/BeaconSearchResults.tsx
@@ -1,10 +1,12 @@
 import { useBeacon } from '@/features/beacon/hooks';
 import SearchResultsPane from '../Search/SearchResultsPane';
 import { WAITING_STATES } from '@/constants/requests';
+import { useCanSeeUncensoredCounts } from '@/hooks/censorship';
 
 const BeaconSearchResults = () => {
   const { queryStatus, results } = useBeacon();
-  const hasInsufficientData = results.individualCount === 0;
+  const uncensoredCounts = useCanSeeUncensoredCounts();
+  const hasInsufficientData = results.individualCount === 0 && !uncensoredCounts;
   const message = hasInsufficientData ? 'Insufficient data available.' : '';
 
   return (

--- a/src/js/components/Search/SearchResults.tsx
+++ b/src/js/components/Search/SearchResults.tsx
@@ -54,7 +54,6 @@ const SearchResults = () => {
     <SearchResultsPane
       isFetchingData={filterQueryStatus === RequestStatus.Pending || textQueryStatus === RequestStatus.Pending}
       hasInsufficientData={hasInsufficientData}
-      uncensoredCounts={uncensoredCounts}
       message={message}
       results={results}
       page={subPage as SearchResultsUIPage}

--- a/src/js/components/Search/SearchResults.tsx
+++ b/src/js/components/Search/SearchResults.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next';
 import { useSelectedScope } from '@/features/metadata/hooks';
 import { useSearchQuery } from '@/features/search/hooks';
 import type { SearchResultsUIPage } from '@/features/search/types';
-import { useCanSeeUncensoredCounts } from '@/hooks/censorship';
 import { RequestStatus } from '@/types/requests';
 import { langAndScopeSelectionToUrl } from '@/utils/router';
 
@@ -47,8 +46,6 @@ const SearchResults = () => {
 
   // existing code treats non-empty message as sign of insufficient data
   const hasInsufficientData = message !== '';
-
-  const uncensoredCounts = useCanSeeUncensoredCounts();
 
   return (
     <SearchResultsPane

--- a/src/js/components/Search/SearchResultsCounts.tsx
+++ b/src/js/components/Search/SearchResultsCounts.tsx
@@ -8,6 +8,7 @@ import CountsTitleWithHelp from '@/components/Util/CountsTitleWithHelp';
 import { COUNTS_FILL } from '@/constants/overviewConstants';
 import { NO_RESULTS_DASHES } from '@/features/search/constants';
 import { useHasScopePermission, useTranslationFn } from '@/hooks';
+import { useCanSeeUncensoredCounts } from '@/hooks/censorship';
 import type { SearchResultsUIPage } from '@/features/search/types';
 import type { DiscoveryResults, OptionalDiscoveryResults } from '@/types/data';
 import { RequestStatus } from '@/types/requests';
@@ -21,7 +22,6 @@ const SearchResultsCounts = ({
   selectedPage,
   setSelectedPage,
   hasInsufficientData,
-  uncensoredCounts,
   message,
 }: SearchResultsCountsProps) => {
   const t = useTranslationFn();
@@ -29,6 +29,7 @@ const SearchResultsCounts = ({
   const { individualCount, biosampleCount, experimentCount } = results;
   const { hasPermission: queryDataPerm } = useHasScopePermission(queryData);
   const individualsClickable = !!setSelectedPage && queryDataPerm;
+  const uncensoredCounts = useCanSeeUncensoredCounts();
 
   const isBeaconNetwork = mode === 'beacon-network';
 
@@ -102,7 +103,6 @@ type SearchResultsCountsProps = {
   selectedPage?: SearchResultsUIPage;
   setSelectedPage?: (page: SearchResultsUIPage) => void;
   hasInsufficientData?: boolean;
-  uncensoredCounts?: boolean;
   message?: string;
 };
 

--- a/src/js/components/Search/SearchResultsPane.tsx
+++ b/src/js/components/Search/SearchResultsPane.tsx
@@ -54,7 +54,6 @@ const SRChartsPage = ({
 const SearchResultsPane = ({
   isFetchingData,
   hasInsufficientData,
-  uncensoredCounts,
   message,
   results,
   resultsTitle,
@@ -109,7 +108,6 @@ const SearchResultsPane = ({
               setSelectedPage={onPageChange}
               results={results}
               hasInsufficientData={hasInsufficientData}
-              uncensoredCounts={uncensoredCounts}
               message={message}
             />
           </Col>
@@ -123,7 +121,6 @@ const SearchResultsPane = ({
 export interface SearchResultsPaneProps {
   isFetchingData: boolean;
   hasInsufficientData?: boolean;
-  uncensoredCounts?: boolean;
   message?: string;
   results: DiscoveryResults;
   resultsTitle?: string;

--- a/src/js/features/beacon/utils.ts
+++ b/src/js/features/beacon/utils.ts
@@ -78,7 +78,7 @@ export const extractBeaconDiscoveryOverview = (response: BeaconQueryResponse): O
   // Bento-specific counts/chart data
   ...(response.info?.bento
     ? {
-        biosampleCount: response?.info.bento.biosamples?.count,
+        biosampleCount: response.info.bento.biosamples?.count,
         biosampleChartData: serializeChartData(response.info.bento.biosamples?.sampled_tissue),
         experimentCount: response.info.bento.experiments?.count,
         experimentChartData: serializeChartData(response.info.bento.experiments?.experiment_type),

--- a/src/js/features/beacon/utils.ts
+++ b/src/js/features/beacon/utils.ts
@@ -78,12 +78,18 @@ export const extractBeaconDiscoveryOverview = (response: BeaconQueryResponse): O
   // Bento-specific counts/chart data
   ...(response.info?.bento
     ? {
-        biosampleCount: response.info.bento.biosamples?.count,
+        biosampleCount: response?.info.bento.biosamples?.count,
         biosampleChartData: serializeChartData(response.info.bento.biosamples?.sampled_tissue),
         experimentCount: response.info.bento.experiments?.count,
         experimentChartData: serializeChartData(response.info.bento.experiments?.experiment_type),
       }
-    : {}),
+    : // no overview is given when zero results
+      {
+        biosampleCount: 0,
+        biosampleChartData: [],
+        experimentCount: 0,
+        experimentChartData: [],
+      }),
 
   // Beacon-standard individuals count
   ...(response.responseSummary

--- a/src/js/hooks/censorship.ts
+++ b/src/js/hooks/censorship.ts
@@ -9,5 +9,5 @@ export const useCanSeeUncensoredCounts = () => {
   // Used mostly for UI - showing dashes vs "0".
   //  - If we have query:data permissions or the low cell count threshold is low enough that we get uncensored counts,
   //    then this becomes true.
-  return queryDataPerm || countThreshold <= 1;
+  return queryDataPerm || countThreshold <= 0;
 };

--- a/src/js/hooks/censorship.ts
+++ b/src/js/hooks/censorship.ts
@@ -7,7 +7,6 @@ export const useCanSeeUncensoredCounts = () => {
   const { countThreshold } = useConfig();
 
   // Used mostly for UI - showing dashes vs "0".
-  //  - If we have query:data permissions or the low cell count threshold is low enough that we get uncensored counts,
-  //    then this becomes true.
+  // True when we have query:data permissions or the low cell count threshold is zero
   return queryDataPerm || countThreshold <= 0;
 };


### PR DESCRIPTION
Handle uncensored zero results from beacon: show "0" instead of "Insufficient data available". (Redmine #2360)

Related changes:
- remove stale beacon search overview values when no results (bug was masked by censored count handling)
- fix threshold handling (threshold is inclusive)
- remove prop drilling for `uncensoredCounts` value

... I'd hoped to eliminate one of the two bools responsible for showing zero or "insufficient data" (`hasInsufficientData` and `uncensoredCounts`) but the first one is a legacy of katsu's response for a censored zero response, which is just:

 `{message: "Insufficient data available."}`

with no actual zero to count. 