### PR TITLE
feat(overview): collapsible overview sections

### DIFF
--- a/src/js/components/Overview/OverviewChartDashboard.tsx
+++ b/src/js/components/Overview/OverviewChartDashboard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Flex, FloatButton, Typography } from 'antd';
+import { Flex, FloatButton } from 'antd';
 import { AppstoreAddOutlined } from '@ant-design/icons';
 
 import { convertSequenceAndDisplayData, saveValue } from '@/utils/localStorage';
@@ -11,11 +11,11 @@ import { WAITING_STATES } from '@/constants/requests';
 
 import AboutBox from './AboutBox';
 import OverviewSection from './OverviewSection';
+import OverviewDatasets from './OverviewDatasets';
 import ManageChartsDrawer from './Drawer/ManageChartsDrawer';
 import Counts from './Counts';
 import LastIngestionInfo from './LastIngestion';
 import Loader from '@/components/Loader';
-import Dataset from '@/components/Provenance/Dataset';
 
 import { useTranslationFn } from '@/hooks';
 import { useData, useSearchableFields } from '@/features/data/hooks';
@@ -63,17 +63,8 @@ const OverviewChartDashboard = () => {
         <Counts />
 
         {selectedProject && !scope.dataset && selectedProject.datasets.length ? (
-          // If we have a project with more than one dataset, show a dataset selector in the project overview
-          <div>
-            <Typography.Title level={3}>Datasets</Typography.Title>
-            <div className="dataset-provenance-card-grid">
-              {selectedProject.datasets.map((d) => (
-                <div key={d.identifier}>
-                  <Dataset parentProjectID={selectedProject.identifier} dataset={d} format="card" />
-                </div>
-              ))}
-            </div>
-          </div>
+          // If we have a project with at least one dataset, show a dataset mini-catalogue in the project overview
+          <OverviewDatasets datasets={selectedProject.datasets} parentProjectID={selectedProject.identifier} />
         ) : null}
 
         {displayedSections.map(({ sectionTitle, charts }, i) => (

--- a/src/js/components/Overview/OverviewDatasets.tsx
+++ b/src/js/components/Overview/OverviewDatasets.tsx
@@ -1,0 +1,17 @@
+import type { Dataset as DatasetT } from '@/types/metadata';
+import Dataset from '@/components/Provenance/Dataset';
+import OverviewCollapsibleSection from './Util/OverviewCollapsibleSection';
+
+const OverviewDatasets = ({ datasets, parentProjectID }: { datasets: DatasetT[]; parentProjectID: string }) => (
+  <OverviewCollapsibleSection title="Datasets">
+    <div className="dataset-provenance-card-grid">
+      {datasets.map((d) => (
+        <div key={d.identifier}>
+          <Dataset parentProjectID={parentProjectID} dataset={d} format="card" />
+        </div>
+      ))}
+    </div>
+  </OverviewCollapsibleSection>
+);
+
+export default OverviewDatasets;

--- a/src/js/components/Overview/OverviewSection.tsx
+++ b/src/js/components/Overview/OverviewSection.tsx
@@ -1,8 +1,6 @@
-import { Typography, Space } from 'antd';
-
-import { useTranslationFn } from '@/hooks';
 import type { ChartDataField } from '@/types/data';
 import OverviewDisplayData from './OverviewDisplayData';
+import OverviewCollapsibleSection from './Util/OverviewCollapsibleSection';
 
 const OverviewSection = ({
   title,
@@ -12,15 +10,10 @@ const OverviewSection = ({
   title: string;
   chartData: ChartDataField[];
   searchableFields: Set<string>;
-}) => {
-  const t = useTranslationFn();
-
-  return (
-    <Space direction="vertical" size={0} className="w-full">
-      <Typography.Title level={3}>{t(title)}</Typography.Title>
-      <OverviewDisplayData section={title} allCharts={chartData} searchableFields={searchableFields} />
-    </Space>
-  );
-};
+}) => (
+  <OverviewCollapsibleSection title={title}>
+    <OverviewDisplayData section={title} allCharts={chartData} searchableFields={searchableFields} />
+  </OverviewCollapsibleSection>
+);
 
 export default OverviewSection;

--- a/src/js/components/Overview/Util/OverviewCollapsibleSection.tsx
+++ b/src/js/components/Overview/Util/OverviewCollapsibleSection.tsx
@@ -1,0 +1,28 @@
+import { type ReactNode, useCallback, useState } from 'react';
+import { Flex, Typography } from 'antd';
+import { useTranslationFn } from '@/hooks';
+import { DownOutlined } from '@ant-design/icons';
+
+const OverviewCollapsibleSection = ({ title, children }: { title: string; children: ReactNode }) => {
+  const t = useTranslationFn();
+
+  // TODO: move to LS if key provided?
+  const [collapsed, setCollapsed] = useState(false);
+  const toggleCollapse = useCallback(() => setCollapsed((c) => !c), []);
+
+  return (
+    <Flex vertical={true} style={{ maxHeight: collapsed ? 32 : 99999, overflow: collapsed ? 'hidden' : 'visible' }}>
+      <Typography.Title level={3} className="cursor-pointer select-none" onClick={toggleCollapse}>
+        <span style={{ color: '#bfbfbf', fontSize: '0.8em' }}>
+          <DownOutlined
+            style={{ transform: `rotate(${collapsed ? '-90' : '0'}deg)`, transition: 'transform 0.1s ease-in-out' }}
+          />
+        </span>{' '}
+        {t(title)}
+      </Typography.Title>
+      {children}
+    </Flex>
+  );
+};
+
+export default OverviewCollapsibleSection;

--- a/src/styles.css
+++ b/src/styles.css
@@ -36,6 +36,7 @@ body {
 .rounded-xl { border-radius: 12px; }
 .rounded-e-none { border-start-end-radius: 0; border-end-end-radius: 0; }
 .cursor-pointer { cursor: pointer; }
+.select-none { user-select: none; }
 .font-mono { font-family: ui-monospace, monospace; }
 .text-center { text-align: center; }
 


### PR DESCRIPTION
goal: allow users to reduce the possibly-overwhelming amount of info shown on the overview page without having to fully hide charts/sections via the chart manager.

also (newly) allows collapsing the overview datasets view.