### PR TITLE
Differentiate local storage keys by scope for chart configurations

### DIFF
--- a/src/js/components/Overview/OverviewChartDashboard.tsx
+++ b/src/js/components/Overview/OverviewChartDashboard.tsx
@@ -2,11 +2,11 @@ import { type CSSProperties, useCallback, useEffect, useState } from 'react';
 import { Col, FloatButton, Row, Typography } from 'antd';
 import { AppstoreAddOutlined } from '@ant-design/icons';
 
-import { convertSequenceAndDisplayData, saveValue } from '@/utils/localStorage';
+import { convertSequenceAndDisplayData, generateLSChartDataKey, saveValue } from '@/utils/localStorage';
 import type { Sections } from '@/types/data';
+import type { DiscoveryScope } from '@/features/metadata/metadata.store';
 import { RequestStatus } from '@/types/requests';
 
-import { LOCALSTORAGE_CHARTS_KEY } from '@/constants/overviewConstants';
 import { WAITING_STATES } from '@/constants/requests';
 
 import AboutBox from './AboutBox';
@@ -25,8 +25,8 @@ import { useSmallScreen } from '@/hooks/useResponsiveContext';
 // The 'right' position will be set based on small screen status dynamically
 const MANAGE_CHARTS_BUTTON_STYLE: CSSProperties = { bottom: '1.5em', transform: 'scale(125%)' };
 
-const saveToLocalStorage = (sections: Sections) => {
-  saveValue(LOCALSTORAGE_CHARTS_KEY, convertSequenceAndDisplayData(sections));
+const saveToLocalStorage = (scope: DiscoveryScope, sections: Sections) => {
+  saveValue(generateLSChartDataKey(scope), convertSequenceAndDisplayData(sections));
 };
 
 const OverviewChartDashboard = () => {
@@ -47,7 +47,7 @@ const OverviewChartDashboard = () => {
   useEffect(() => {
     // Save sections to localStorage when they change
     if (overviewDataStatus != RequestStatus.Fulfilled) return;
-    saveToLocalStorage(sections);
+    saveToLocalStorage(scope, sections);
   }, [overviewDataStatus, sections]);
 
   const displayedSections = sections.filter(({ charts }) => charts.findIndex(({ isDisplayed }) => isDisplayed) !== -1);
@@ -56,7 +56,7 @@ const OverviewChartDashboard = () => {
   const onManageChartsClose = useCallback(() => {
     setDrawerVisible(false);
     // When we close the drawer, save any changes to localStorage. This helps ensure width gets saved:
-    saveToLocalStorage(sections);
+    saveToLocalStorage(scope, sections);
   }, [sections]);
 
   return WAITING_STATES.includes(overviewDataStatus) ? (

--- a/src/js/constants/overviewConstants.ts
+++ b/src/js/constants/overviewConstants.ts
@@ -3,7 +3,7 @@ import type { HexColor } from 'bento-charts';
 
 export const COUNTS_FILL = '#75787a';
 
-export const LOCALSTORAGE_CHARTS_KEY = 'charts';
+export const LOCALSTORAGE_CHARTS_KEY_PREFIX = 'charts_scope-';
 
 export const CHART_HEIGHT = 350;
 export const PIE_CHART_HEIGHT = 300; // rendered slightly smaller since labels can clip

--- a/src/js/features/data/makeGetDataRequest.thunk.ts
+++ b/src/js/features/data/makeGetDataRequest.thunk.ts
@@ -10,7 +10,7 @@ import { scopedAuthorizedRequestConfig } from '@/utils/requests';
 
 import type { RootState } from '@/store';
 import type { ChartConfig } from '@/types/chartConfig';
-import type { ChartDataField, LocalStorageData, Sections } from '@/types/data';
+import type { ChartDataField, LocalStorageChartData, Sections } from '@/types/data';
 import type { Counts, OverviewResponse } from '@/types/overviewResponse';
 import { RequestStatus } from '@/types/requests';
 
@@ -55,7 +55,7 @@ export const makeGetDataRequestThunk = createAsyncThunk<
 
     // comparing to the local store and updating itself
     let convertedData = convertSequenceAndDisplayData(sectionData);
-    const localValue = getValue(LOCALSTORAGE_CHARTS_KEY, convertedData, (val: LocalStorageData) =>
+    const localValue = getValue(LOCALSTORAGE_CHARTS_KEY, convertedData, (val: LocalStorageChartData) =>
       verifyData(val, convertedData)
     );
     sectionData.forEach(({ sectionTitle, charts }, i, arr) => {

--- a/src/js/types/data.ts
+++ b/src/js/types/data.ts
@@ -30,9 +30,7 @@ export interface ChartData {
   y: number;
 }
 
-export type LocalStorageChartData = {
-  [key in string]: { id: string; isDisplayed: boolean; width: number }[];
-};
+export type LocalStorageChartData = Record<string, { id: string; isDisplayed: boolean; width: number }[]>;
 
 export type OptionalDiscoveryResults = {
   // individuals

--- a/src/js/types/data.ts
+++ b/src/js/types/data.ts
@@ -30,7 +30,7 @@ export interface ChartData {
   y: number;
 }
 
-export type LocalStorageData = {
+export type LocalStorageChartData = {
   [key in string]: { id: string; isDisplayed: boolean; width: number }[];
 };
 

--- a/src/js/utils/localStorage.ts
+++ b/src/js/utils/localStorage.ts
@@ -27,6 +27,15 @@ export const saveValue = (key: string, value: any) => {
   }
 };
 
+/**
+ * Safely retrieves and parses a value of type `T` from `localStorage`.
+ *
+ * @template T
+ * @param {string} key - The `localStorage` key under which the value is stored.
+ * @param {T} defaultVal - The value to return if the key does not exist, parsing fails, or validation fails.
+ * @param {(arg: any) => boolean} verifyFunc - A predicate that receives the parsed value and returns `true` if it’s valid.
+ * @returns {T} The parsed and validated value from `localStorage`, or `defaultVal` otherwise.
+ */
 export const getValue = <T>(key: string, defaultVal: T, verifyFunc: (arg: any) => boolean): T => {
   try {
     const serializedState = localStorage.getItem(key);

--- a/src/js/utils/localStorage.ts
+++ b/src/js/utils/localStorage.ts
@@ -1,6 +1,9 @@
+import { LOCALSTORAGE_CHARTS_KEY_PREFIX } from '@/constants/overviewConstants';
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { LocalStorageChartData, Sections } from '@/types/data';
 import type { ValueOf } from '@/types/util';
+import type { DiscoveryScope } from '@/features/metadata/metadata.store';
 
 export const verifyData = (nObj: any, oObj: LocalStorageChartData) => {
   const verifyCharts = (nCharts: any, oCharts: ValueOf<LocalStorageChartData>) => {
@@ -61,4 +64,13 @@ export const convertSequenceAndDisplayData = (sections: Sections) => {
     temp[sectionTitle] = charts.map(({ id, isDisplayed, width }) => ({ id, isDisplayed, width }));
   });
   return temp;
+};
+
+export const generateLSChartDataKey = (scope: DiscoveryScope) => {
+  const { project: p, dataset: d } = scope;
+  const scopeString = p ? (d ?? p) : '';
+
+  // Relies on the fact that project and dataset ids are unique
+  const lsKey = `${LOCALSTORAGE_CHARTS_KEY_PREFIX}${scopeString}`;
+  return lsKey;
 };

--- a/src/js/utils/localStorage.ts
+++ b/src/js/utils/localStorage.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { LocalStorageData, Sections } from '@/types/data';
+import type { LocalStorageChartData, Sections } from '@/types/data';
 import type { ValueOf } from '@/types/util';
 
-export const verifyData = (nObj: any, oObj: LocalStorageData) => {
-  const verifyCharts = (nCharts: any, oCharts: ValueOf<LocalStorageData>) => {
+export const verifyData = (nObj: any, oObj: LocalStorageChartData) => {
+  const verifyCharts = (nCharts: any, oCharts: ValueOf<LocalStorageChartData>) => {
     if (nCharts.length !== oCharts.length) return false;
 
     const nChartsMap: { [key in string]: boolean } = {};
@@ -47,7 +47,7 @@ export const getValue = <T>(key: string, defaultVal: T, verifyFunc: (arg: any) =
 };
 
 export const convertSequenceAndDisplayData = (sections: Sections) => {
-  const temp: LocalStorageData = {};
+  const temp: LocalStorageChartData = {};
   sections.forEach(({ sectionTitle, charts }) => {
     temp[sectionTitle] = charts.map(({ id, isDisplayed, width }) => ({ id, isDisplayed, width }));
   });


### PR DESCRIPTION
Previously, all chart layout configurations were stored under a shared localStorage key, causing conflicts across scopes. This update introduces per-scope storage separation to isolate layouts based on their respective context, ensuring compatibility and preventing unintentional overrides.