### PR TITLE
fix(SiteHeader): update logo source for small screen display

### DIFF
--- a/src/js/components/SiteHeader.tsx
+++ b/src/js/components/SiteHeader.tsx
@@ -56,7 +56,7 @@ const SiteHeader = () => {
           {isSmallScreen ? (
             <object
               type="image/png"
-              data="/public/assets/icon_small.png"
+              data="/public/assets/branding.png"
               aria-label="logo"
               style={{ height: '32px', verticalAlign: 'middle', transform: 'translateY(-3px)', paddingRight: '26px' }}
               onClick={navigateToOverview}


### PR DESCRIPTION
As none of the portals support small icon yet. On small screens, the brading was resetting to a bento logo which isn't ideal. This changes that behavior.