### PR TITLE
use beacon-standard filters in beacon network

### DIFF
--- a/src/js/features/beacon/network.store.ts
+++ b/src/js/features/beacon/network.store.ts
@@ -23,7 +23,7 @@ import {
   extractBeaconDiscoveryOverview,
   networkAssemblyIds,
   networkQueryUrl,
-  packageBeaconNetworkQuerySections,
+  packageBeaconFilteringTerms,
 } from './utils';
 
 // can parameterize at some point in the future
@@ -136,11 +136,11 @@ const beaconNetwork = createSlice({
       state.networkConfigStatus = RequestStatus.Pending;
     });
     builder.addCase(getBeaconNetworkConfig.fulfilled, (state, { payload }) => {
-      const allFilters = packageBeaconNetworkQuerySections(payload.filtersUnion);
+      const allFilters = packageBeaconFilteringTerms(payload.filtersUnion);
       state.networkConfigStatus = RequestStatus.Fulfilled;
       state.beacons = payload.beacons;
       state.filtersUnion = allFilters;
-      state.filtersIntersection = packageBeaconNetworkQuerySections(payload.filtersIntersection);
+      state.filtersIntersection = packageBeaconFilteringTerms(payload.filtersIntersection);
       state.currentFilters = allFilters;
       state.assemblyIds = networkAssemblyIds(payload.beacons);
     });

--- a/src/js/types/beacon.ts
+++ b/src/js/types/beacon.ts
@@ -185,6 +185,7 @@ export interface BeaconFilteringTermFromEndpoint {
   values: string[];
   bento: {
     section: string;
+    mapping?: string;
   };
   units?: string;
 }

--- a/src/js/types/beaconNetwork.ts
+++ b/src/js/types/beaconNetwork.ts
@@ -1,5 +1,4 @@
-import type { Section } from '@/features/search/types';
-import type { BeaconServiceInfo, BeaconQueryPayload } from '@/types/beacon';
+import type { BeaconFilteringTermFromEndpoint, BeaconServiceInfo, BeaconQueryPayload } from '@/types/beacon';
 
 export interface NetworkBeacon extends BeaconServiceInfo {
   apiUrl: string;
@@ -19,8 +18,8 @@ export interface NetworkBeacon extends BeaconServiceInfo {
 
 // more to come here
 export interface BeaconNetworkConfig {
-  filtersUnion: Section[];
-  filtersIntersection: Section[];
+  filtersUnion: BeaconFilteringTermFromEndpoint[];
+  filtersIntersection: BeaconFilteringTermFromEndpoint[];
   beacons: NetworkBeacon[];
 }
 


### PR DESCRIPTION
Requires [Beacon pr #138](https://github.com/bento-platform/bento_beacon/pull/138).

Deprecate the use of katsu-format querySections in beacon network, use beacon filtering terms only. 