### PR TITLE
More improvements for phenopacket display

### DIFF
--- a/src/js/components/ClinPhen/PhenopacketDisplay/BiosampleView.tsx
+++ b/src/js/components/ClinPhen/PhenopacketDisplay/BiosampleView.tsx
@@ -112,7 +112,7 @@ const BiosampleExpandedRow = ({ biosample }: { biosample: Biosample }) => {
   return <TDescriptions bordered size="small" items={items} />;
 };
 
-const isBiosampleRowVisible = (r: Biosample) =>
+const isBiosampleRowExpandable = (r: Biosample) =>
   !!(
     r.description ||
     r.derived_from_id ||
@@ -157,7 +157,7 @@ const BiosampleView = ({ biosamples }: BiosampleViewProps) => {
       columns={BIOSAMPLE_VIEW_COLUMNS}
       expandedRowRender={(record) => <BiosampleExpandedRow biosample={record} />}
       rowKey="id"
-      isDataKeyVisible={isBiosampleRowVisible}
+      isRowExpandable={isBiosampleRowExpandable}
     />
   );
 };

--- a/src/js/components/ClinPhen/PhenopacketDisplay/DiseasesView.tsx
+++ b/src/js/components/ClinPhen/PhenopacketDisplay/DiseasesView.tsx
@@ -54,7 +54,7 @@ interface DiseasesViewProps {
   diseases: Disease[];
 }
 
-const isDiseaseRowVisible = (r: Disease) =>
+const isDiseaseRowExpandable = (r: Disease) =>
   !!(r.disease_stage?.length || r.clinical_tnm_finding?.length || r.primary_site || r.laterality || r.extra_properties);
 
 const DISEASES_VIEW_COLUMNS: CustomTableColumns<Disease> = [
@@ -88,7 +88,7 @@ const DiseasesView = ({ diseases }: DiseasesViewProps) => {
       columns={DISEASES_VIEW_COLUMNS}
       expandedRowRender={(record) => <DiseaseExpandedRow disease={record} />}
       rowKey={(record) => record.term.id}
-      isDataKeyVisible={isDiseaseRowVisible}
+      isRowExpandable={isDiseaseRowExpandable}
     />
   );
 };

--- a/src/js/components/ClinPhen/PhenopacketDisplay/InterpretationsView.tsx
+++ b/src/js/components/ClinPhen/PhenopacketDisplay/InterpretationsView.tsx
@@ -46,7 +46,7 @@ const GenomicInterpretationDetails = ({ genomicInterpretation }: { genomicInterp
   return <TDescriptions items={items} size="small" column={1} bordered />;
 };
 
-const isGenomicInterpretationDetailsVisible = (r: GenomicInterpretation) =>
+const isGenomicInterpretationDetailsExpandable = (r: GenomicInterpretation) =>
   !!(r.variant_interpretation || r.gene_descriptor);
 
 const InterpretationsExpandedRow = ({ interpretation }: { interpretation: Interpretation }) => {
@@ -101,7 +101,7 @@ const InterpretationsExpandedRow = ({ interpretation }: { interpretation: Interp
               <GenomicInterpretationDetails genomicInterpretation={record} />
             )}
             rowKey={(record: GenomicInterpretation) => record.subject_or_biosample_id}
-            isDataKeyVisible={isGenomicInterpretationDetailsVisible}
+            isRowExpandable={isGenomicInterpretationDetailsExpandable}
             queryKey="gi"
           />
         ) : (
@@ -154,7 +154,7 @@ const InterpretationsView = ({ interpretations }: InterpretationsViewProps) => {
       columns={columns}
       expandedRowRender={(record) => <InterpretationsExpandedRow interpretation={record} />}
       rowKey={(record) => record.id}
-      isDataKeyVisible={isInterpretationDetailsVisible}
+      isRowExpandable={isInterpretationDetailsVisible}
     />
   );
 };

--- a/src/js/components/ClinPhen/PhenopacketDisplay/InterpretationsView.tsx
+++ b/src/js/components/ClinPhen/PhenopacketDisplay/InterpretationsView.tsx
@@ -120,18 +120,6 @@ const InterpretationsView = ({ interpretations }: InterpretationsViewProps) => {
       alwaysShow: true,
     },
     {
-      title: 'interpretations.created',
-      dataIndex: 'created',
-      key: 'created',
-      render: (text: string) => <Tooltip title={text}>{new Date(text).toLocaleDateString()}</Tooltip>,
-    },
-    {
-      title: 'interpretations.updated',
-      dataIndex: 'updated',
-      key: 'updated',
-      render: (text: string) => <Tooltip title={text}>{new Date(text).toLocaleDateString()}</Tooltip>,
-    },
-    {
       title: 'interpretations.progress_status',
       dataIndex: 'progress_status',
       key: 'progress_status',

--- a/src/js/components/ClinPhen/PhenopacketDisplay/InterpretationsView.tsx
+++ b/src/js/components/ClinPhen/PhenopacketDisplay/InterpretationsView.tsx
@@ -63,7 +63,7 @@ const InterpretationsExpandedRow = ({ interpretation }: { interpretation: Interp
     {
       title: 'interpretations.interpretation_status',
       dataIndex: 'interpretation_status',
-      render: (text: string) => t(`genomic_intepretation_status.${text}`),
+      render: (text: string) => t(`genomic_interpretation_status.${text}`),
     },
   ];
 

--- a/src/js/components/ClinPhen/PhenopacketDisplay/InterpretationsView.tsx
+++ b/src/js/components/ClinPhen/PhenopacketDisplay/InterpretationsView.tsx
@@ -19,7 +19,16 @@ const GenomicInterpretationDetails = ({ genomicInterpretation }: { genomicInterp
   const relatedType = (genomicInterpretation?.extra_properties as JSONObject)?.__related_type ?? 'unknown';
 
   const items: ConditionalDescriptionItem[] = [
-    { key: 'id', label: `${relatedType} id`, children: genomicInterpretation.subject_or_biosample_id! }, //TODO: Link to subject or biosample
+    {
+      key: 'id',
+      label:
+        relatedType === 'subject'
+          ? 'subject.subject'
+          : relatedType === 'biosample'
+            ? 'entities.biosample_one'
+            : 'Unknown',
+      children: genomicInterpretation.subject_or_biosample_id!,
+    }, //TODO: Link to subject or biosample
     {
       key: 'Variant Interpretation',
       label: 'interpretations.variant_interpretation',

--- a/src/js/components/ClinPhen/PhenopacketDisplay/InterpretationsView.tsx
+++ b/src/js/components/ClinPhen/PhenopacketDisplay/InterpretationsView.tsx
@@ -1,4 +1,4 @@
-import { Space, Tooltip, Typography } from 'antd';
+import { Space, Typography } from 'antd';
 import { MedicineBoxOutlined, ExperimentOutlined } from '@ant-design/icons';
 
 import CustomEmpty from '@Util/CustomEmpty';

--- a/src/js/components/ClinPhen/PhenopacketDisplay/InterpretationsView.tsx
+++ b/src/js/components/ClinPhen/PhenopacketDisplay/InterpretationsView.tsx
@@ -46,8 +46,8 @@ const InterpretationsExpandedRow = ({ interpretation }: { interpretation: Interp
     {
       key: 'Disease',
       label: 'interpretations.disease',
-      children: <OntologyTerm term={interpretation?.diagnosis?.disease} />,
-      isVisible: interpretation?.diagnosis?.disease,
+      children: <OntologyTerm term={interpretation.diagnosis?.disease} />,
+      isVisible: interpretation.diagnosis?.disease,
     },
   ];
 

--- a/src/js/components/ClinPhen/PhenopacketDisplay/InterpretationsView.tsx
+++ b/src/js/components/ClinPhen/PhenopacketDisplay/InterpretationsView.tsx
@@ -13,6 +13,7 @@ import type { Interpretation } from '@/types/clinPhen/interpretation';
 import type { JSONObject } from '@/types/json';
 import type { GenomicInterpretation } from '@/types/clinPhen/genomicInterpretation';
 import type { ConditionalDescriptionItem } from '@/types/descriptions';
+import type { Diagnosis } from '@/types/clinPhen/diagnosis';
 
 const GenomicInterpretationDetails = ({ genomicInterpretation }: { genomicInterpretation: GenomicInterpretation }) => {
   const relatedType = (genomicInterpretation?.extra_properties as JSONObject)?.__related_type ?? 'unknown';
@@ -124,6 +125,11 @@ const InterpretationsView = ({ interpretations }: InterpretationsViewProps) => {
       dataIndex: 'progress_status',
       key: 'progress_status',
       render: (text: string) => t(`progress_status.${text}`),
+    },
+    {
+      title: 'interpretations.disease_diagnosis',
+      dataIndex: 'diagnosis',
+      render: (diagnosis: Diagnosis | undefined) => <OntologyTerm term={diagnosis?.disease} />,
     },
     {
       title: 'interpretations.summary',

--- a/src/js/components/ClinPhen/PhenopacketDisplay/MeasurementsView.tsx
+++ b/src/js/components/ClinPhen/PhenopacketDisplay/MeasurementsView.tsx
@@ -102,8 +102,9 @@ const MeasurementDetail = ({ measurement, expanded }: { measurement: Measurement
   return null;
 };
 
-const isMeasurementExpandedRowVisible = (measurement: Measurement) =>
+const isMeasurementExpandable = (measurement: Measurement) =>
   !!(measurement.procedure || measurement.value || measurement.complex_value);
+
 interface MeasurementsViewProps {
   measurements: Measurement[];
 }
@@ -142,7 +143,7 @@ const MeasurementsView = ({ measurements }: MeasurementsViewProps) => {
       columns={columns}
       expandedRowRender={(record) => <MeasurementsExpandedRow measurement={record} />}
       rowKey={(record) => record.assay.id}
-      isDataKeyVisible={isMeasurementExpandedRowVisible}
+      isRowExpandable={isMeasurementExpandable}
     />
   );
 };

--- a/src/js/components/ClinPhen/PhenopacketDisplay/MedicalActionsView.tsx
+++ b/src/js/components/ClinPhen/PhenopacketDisplay/MedicalActionsView.tsx
@@ -263,7 +263,12 @@ const MedicalActionsView = ({ medicalActions }: { medicalActions: MedicalAction[
       columns={columns}
       expandedRowRender={(record) => <MedicalActionDetails medicalAction={record} />}
       rowKey={(record) =>
-        record.procedure?.code?.id || record.treatment?.agent?.id || record.radiation_therapy?.modality?.id || 'unknown'
+        record.procedure?.code?.id ??
+        record.treatment?.agent?.id ??
+        record.radiation_therapy?.modality?.id ??
+        record.therapeutic_regimen?.ontology_class?.id ??
+        record.therapeutic_regimen?.external_reference?.id ??
+        'unknown'
       }
       isDataKeyVisible={isMedicalActionsExpandedRowVisible}
     />

--- a/src/js/components/ClinPhen/PhenopacketDisplay/MedicalActionsView.tsx
+++ b/src/js/components/ClinPhen/PhenopacketDisplay/MedicalActionsView.tsx
@@ -119,56 +119,59 @@ const RadiationTherapyComponent = ({ radiationTherapy }: { radiationTherapy: Rad
   return <TDescriptions bordered column={1} size="small" items={radiationTherapyItems} />;
 };
 
-const TherapeuticRegimenComponent = ({ therapeutic_regimen }: { therapeutic_regimen: TherapeuticRegimen }) => {
+const TherapeuticRegimenIdentifier = ({ regimen }: { regimen: TherapeuticRegimen }) => {
   const t = useTranslationFn();
+  return (
+    <>
+      {regimen.ontology_class ?? <OntologyTermComponent term={regimen.ontology_class} />}
+      {regimen.external_reference && (
+        <Flex vertical>
+          <div>
+            <strong>ID:</strong>
+            {regimen?.external_reference?.id ?? EM_DASH}
+          </div>
+          <div>
+            <strong>{t('medical_actions.reference')}:</strong>
+            {t(regimen?.external_reference?.reference) ?? EM_DASH}
+          </div>
+          <div>
+            <strong>{t('Description')}:</strong>
+            {t(regimen?.external_reference?.description) ?? EM_DASH}
+          </div>
+        </Flex>
+      )}
+    </>
+  );
+};
 
-  const TherapeuticRegimenItems: ConditionalDescriptionItem[] = [
+const TherapeuticRegimenComponent = ({ regimen }: { regimen: TherapeuticRegimen }) => {
+  const items: ConditionalDescriptionItem[] = [
     {
       key: 'identifier',
       label: 'medical_actions.identifier',
-      children: (
-        <>
-          {therapeutic_regimen.ontology_class ?? <OntologyTermComponent term={therapeutic_regimen.ontology_class} />}
-          {therapeutic_regimen.external_reference && (
-            <Flex vertical>
-              <div>
-                <strong>ID:</strong>
-                {therapeutic_regimen?.external_reference?.id ?? EM_DASH}
-              </div>
-              <div>
-                <strong>{t('medical_actions.reference')}:</strong>
-                {t(therapeutic_regimen?.external_reference?.reference) ?? EM_DASH}
-              </div>
-              <div>
-                <strong>Description:</strong>
-                {t(therapeutic_regimen?.external_reference?.description) ?? EM_DASH}
-              </div>
-            </Flex>
-          )}
-        </>
-      ),
-      isVisible: therapeutic_regimen.ontology_class || therapeutic_regimen.external_reference,
+      children: <TherapeuticRegimenIdentifier regimen={regimen} />,
+      isVisible: regimen.ontology_class || regimen.external_reference,
     },
     {
       key: 'start_time',
       label: 'medical_actions.start_time',
-      children: <TimeElementDisplay element={therapeutic_regimen.start_time} />,
-      isVisible: therapeutic_regimen.start_time,
+      children: <TimeElementDisplay element={regimen.start_time} />,
+      isVisible: regimen.start_time,
     },
     {
       key: 'end_time',
       label: 'medical_actions.end_time',
-      children: <TimeElementDisplay element={therapeutic_regimen.end_time} />,
-      isVisible: therapeutic_regimen.end_time,
+      children: <TimeElementDisplay element={regimen.end_time} />,
+      isVisible: regimen.end_time,
     },
     {
       key: 'status',
       label: 'medical_actions.status',
-      children: therapeutic_regimen.status,
-      isVisible: therapeutic_regimen.status,
+      children: regimen.status,
+      isVisible: regimen.status,
     },
   ];
-  return <TDescriptions bordered column={1} size="small" items={TherapeuticRegimenItems} />;
+  return <TDescriptions bordered column={1} size="small" items={items} />;
 };
 
 const MedicalActionDetails = ({ medicalAction }: { medicalAction: MedicalAction }) => {
@@ -194,7 +197,7 @@ const MedicalActionDetails = ({ medicalAction }: { medicalAction: MedicalAction 
     {
       key: 'therapeuticRegimen',
       label: 'medical_actions.therapeutic_regimen',
-      children: <TherapeuticRegimenComponent therapeutic_regimen={medicalAction.therapeutic_regimen!} />,
+      children: <TherapeuticRegimenComponent regimen={medicalAction.therapeutic_regimen!} />,
       isVisible: medicalAction.therapeutic_regimen,
     },
     {
@@ -217,15 +220,48 @@ const MedicalActionsView = ({ medicalActions }: { medicalActions: MedicalAction[
       title: 'medical_actions.action_type',
       key: 'actionType',
       render: (_: undefined, action: MedicalAction) => {
-        if (action.procedure) return t('medical_actions.procedure');
-        if (action.treatment) return t('medical_actions.treatment');
-        if (action.radiation_therapy) return t('medical_actions.radiation_therapy');
-        if (action.therapeutic_regimen) return t('medical_actions.therapeutic_regimen');
-        return (
-          <Text type="secondary" italic>
-            {t('medical_actions.unknown')}
-          </Text>
-        );
+        // Each of the medical action types has at least one additional required property (often in effect the "ID" of
+        // the medical action) we can show beyond just the type name.
+        // Procedure: procedure code
+        // Treatment: agent
+        // Radiation therapy: modality, body site, dosage, fractions - for now we show the first two in the table
+        // Therapeutic regimen: identifier
+        if (action.procedure) {
+          return (
+            <>
+              {t('medical_actions.procedure')} ({t('clinphen_generic.code')}:{' '}
+              <OntologyTermComponent term={action.procedure.code} />)
+            </>
+          );
+        } else if (action.treatment) {
+          return (
+            <>
+              {t('medical_actions.treatment')} ({t('medical_actions.agent')}:{' '}
+              <OntologyTermComponent term={action.treatment.agent} />)
+            </>
+          );
+        } else if (action.radiation_therapy) {
+          return (
+            <>
+              {t('medical_actions.radiation_therapy')} ({t('medical_actions.modality')}:{' '}
+              <OntologyTermComponent term={action.radiation_therapy.modality} />, {t('medical_actions.body_site')}:{' '}
+              <OntologyTermComponent term={action.radiation_therapy.body_site} />)
+            </>
+          );
+        } else if (action.therapeutic_regimen) {
+          return (
+            <>
+              {t('medical_actions.therapeutic_regimen')} ({t('medical_actions.identifier')}:{' '}
+              <TherapeuticRegimenIdentifier regimen={action.therapeutic_regimen} />)
+            </>
+          );
+        } else {
+          return (
+            <Text type="secondary" italic>
+              {t('medical_actions.unknown')}
+            </Text>
+          );
+        }
       },
       alwaysShow: true,
     },

--- a/src/js/components/ClinPhen/PhenopacketDisplay/MedicalActionsView.tsx
+++ b/src/js/components/ClinPhen/PhenopacketDisplay/MedicalActionsView.tsx
@@ -71,7 +71,7 @@ const TreatmentComponent = ({ treatment }: { treatment: Treatment }) => {
           columns={DOSE_INTERVAL_COLUMNS}
           dataSource={addId(treatment.dose_intervals || [])}
           rowKey={(record) => record.id}
-          isDataKeyVisible={() => true}
+          isRowExpandable={() => true}
         />
       ),
       isVisible: treatment?.dose_intervals,
@@ -210,8 +210,21 @@ const MedicalActionDetails = ({ medicalAction }: { medicalAction: MedicalAction 
   return <TDescriptions bordered column={1} size="small" items={medicalActionItems} />;
 };
 
-const isMedicalActionsExpandedRowVisible = (r: MedicalAction) =>
-  !!(r.adverse_events?.length || r.procedure || r.treatment || r.radiation_therapy || r.therapeutic_regimen);
+// Cases:
+//  - Procedure: we'll automatically show code in the actionType column.
+//    This should only be expandable if we have other procedure data not shown in the main table (body_site/performed)
+//  - Treatment: agent is required. If we have any more keys, the row should be expandable.
+//  - Radiation therapy: all keys are required; if this is present at all, the row should be expandable.
+//  - Therapeutic regimen: ID & status are required, but we only show ID in the table itself, so if present, expandable.
+const isMedicalActionExpandable = (r: MedicalAction) =>
+  !!(
+    r.adverse_events?.length ||
+    r.procedure?.body_site ||
+    r.procedure?.performed ||
+    Object.keys(r.treatment ?? {}).length > 1 ||
+    r.radiation_therapy ||
+    r.therapeutic_regimen
+  );
 
 const MedicalActionsView = ({ medicalActions }: { medicalActions: MedicalAction[] }) => {
   const t = useTranslationFn();
@@ -306,7 +319,7 @@ const MedicalActionsView = ({ medicalActions }: { medicalActions: MedicalAction[
         record.therapeutic_regimen?.external_reference?.id ??
         'unknown'
       }
-      isDataKeyVisible={isMedicalActionsExpandedRowVisible}
+      isRowExpandable={isMedicalActionExpandable}
     />
   );
 };

--- a/src/js/components/ClinPhen/PhenopacketDisplay/OntologiesView.tsx
+++ b/src/js/components/ClinPhen/PhenopacketDisplay/OntologiesView.tsx
@@ -29,7 +29,9 @@ const OntologiesView = ({ resources }: OntologiesProps) => {
     { title: 'ontologies.version', dataIndex: 'version' },
     { title: 'ontologies.iri_prefix', dataIndex: 'iri_prefix' },
   ]);
-  return <Table<Resource> dataSource={resources} columns={columns} rowKey="id" pagination={false} bordered />;
+  return (
+    <Table<Resource> dataSource={resources} columns={columns} rowKey="id" pagination={false} bordered size="small" />
+  );
 };
 
 export default OntologiesView;

--- a/src/js/components/ClinPhen/PhenopacketDisplay/PhenotypicFeaturesView.tsx
+++ b/src/js/components/ClinPhen/PhenopacketDisplay/PhenotypicFeaturesView.tsx
@@ -99,7 +99,7 @@ function PhenotypicFeatureExpandedRow({ feature }: { feature: PhenotypicFeature 
   return <TDescriptions bordered size="small" items={items} />;
 }
 
-const isPhenotypicFeatureExpandedRowVisible = (record: PhenotypicFeature) =>
+const isPhenotypicFeatureExpandable = (record: PhenotypicFeature) =>
   !!record.description ||
   !!record.modifiers?.length ||
   (record.evidence && record.evidence.length > 0) ||
@@ -149,7 +149,7 @@ const PhenotypicFeaturesView = ({ features }: PhenotypicFeaturesViewProps) => {
       columns={PHENOTYPIC_FEATURES_COLUMNS}
       expandedRowRender={(record) => <PhenotypicFeatureExpandedRow feature={record} />}
       rowKey={(record) => record.type.id}
-      isDataKeyVisible={isPhenotypicFeatureExpandedRowVisible}
+      isRowExpandable={isPhenotypicFeatureExpandable}
     />
   );
 };

--- a/src/js/components/ClinPhen/PhenopacketDisplay/SubjectView.tsx
+++ b/src/js/components/ClinPhen/PhenopacketDisplay/SubjectView.tsx
@@ -11,7 +11,7 @@ import type { ConditionalDescriptionItem } from '@/types/descriptions';
 import { EM_DASH } from '@/constants/common';
 
 const SubjectView = ({ subject }: { subject: Individual }) => {
-  const vs = subject?.vital_status;
+  const vs = subject.vital_status;
   const vitalStatusItems: ConditionalDescriptionItem[] = [
     {
       key: 'status',
@@ -47,7 +47,7 @@ const SubjectView = ({ subject }: { subject: Individual }) => {
     {
       key: 'Age',
       label: 'subject.age',
-      children: `${subject?.age_numeric} ${subject?.age_unit}`,
+      children: `${subject.age_numeric} ${subject.age_unit}`,
     },
     {
       key: 'alternate_ids',
@@ -58,38 +58,38 @@ const SubjectView = ({ subject }: { subject: Individual }) => {
     {
       key: 'time_at_last_encounter',
       label: 'subject.time_at_last_encounter',
-      children: <TimeElementDisplay element={subject?.time_at_last_encounter} />,
-      isVisible: subject?.time_at_last_encounter,
+      children: <TimeElementDisplay element={subject.time_at_last_encounter} />,
+      isVisible: subject.time_at_last_encounter,
     },
     {
       key: 'vital_status',
       label: 'subject.vital_status',
       children: <TDescriptions items={vitalStatusItems} />,
-      isVisible: subject?.vital_status,
+      isVisible: subject.vital_status,
     },
     {
       key: 'sex',
       label: 'subject.sex',
-      children: subject?.sex,
+      children: subject.sex,
     },
     {
       key: 'karyotypic_sex',
       label: 'subject.karyotypic_sex',
-      children: subject?.karyotypic_sex,
+      children: subject.karyotypic_sex,
     },
     {
       key: 'taxonomy',
       label: 'subject.taxonomy',
       children: (
         <em>
-          <OntologyTerm term={subject?.taxonomy} />
+          <OntologyTerm term={subject.taxonomy} />
         </em>
       ),
-      isVisible: subject?.taxonomy,
+      isVisible: subject.taxonomy,
     },
   ];
 
-  const extraProperties = Object.entries(subject?.extra_properties ?? {}).map(([key, value]) => ({
+  const extraProperties = Object.entries(subject.extra_properties ?? {}).map(([key, value]) => ({
     key,
     label: key,
     children: (typeof value === 'string' || typeof value === 'number' ? value : <JsonView src={value} />) ?? EM_DASH,

--- a/src/js/components/ClinPhen/PhenopacketDisplay/SubjectView.tsx
+++ b/src/js/components/ClinPhen/PhenopacketDisplay/SubjectView.tsx
@@ -96,9 +96,9 @@ const SubjectView = ({ subject }: { subject: Individual }) => {
   }));
 
   return (
-    <Space id="subject-view" direction="vertical" className="w-full" size="large">
-      <TDescriptions items={items} column={1} bordered />
-      {!!extraProperties.length && <TDescriptions items={extraProperties} column={1} bordered />}
+    <Space id="subject-view" direction="vertical" className="w-full" size="middle">
+      <TDescriptions items={items} column={1} bordered size="small" />
+      {!!extraProperties.length && <TDescriptions items={extraProperties} column={1} bordered size="small" />}
     </Space>
   );
 };

--- a/src/js/components/ClinPhen/PhenopacketDisplay/SubjectView.tsx
+++ b/src/js/components/ClinPhen/PhenopacketDisplay/SubjectView.tsx
@@ -78,6 +78,12 @@ const SubjectView = ({ subject }: { subject: Individual }) => {
       children: subject.karyotypic_sex,
     },
     {
+      key: 'gender',
+      label: 'subject.gender',
+      children: subject.gender ? <OntologyTerm term={subject.gender} /> : null,
+      isVisible: subject.gender,
+    },
+    {
       key: 'taxonomy',
       label: 'subject.taxonomy',
       children: (

--- a/src/js/components/ClinPhen/PhenopacketView.tsx
+++ b/src/js/components/ClinPhen/PhenopacketView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { Card, Empty, Flex } from 'antd';
+import { Card, Empty, Flex, Typography } from 'antd';
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 
@@ -13,6 +13,8 @@ import { RequestStatus } from '@/types/requests';
 import { usePhenopacketData } from '@/features/clinPhen/hooks';
 import { useTranslationFn } from '@/hooks';
 import { useNotify } from '@/hooks/notifications';
+
+const { Text } = Typography;
 
 export interface RouteParams {
   packetId: string;
@@ -84,10 +86,26 @@ const PhenopacketView = () => {
     return <Loader fullHeight={false} />;
   }
 
+  const biosamples = phenopacket.biosamples ?? [];
+
   return (
     <Flex justify="center">
       <Card
-        title={packetId}
+        title={
+          <span>
+            {phenopacket.subject ? (
+              phenopacket.subject.id
+            ) : (
+              <>
+                {t('entities.biosample', { count: biosamples.length })}
+                {biosamples.map((b) => b.id).join(', ')}
+              </>
+            )}{' '}
+            <Text type="secondary" italic={true} className="font-normal">
+              (Phenopacket ID: <span className="font-mono">{packetId}</span>)
+            </Text>
+          </span>
+        }
         className="container"
         activeTabKey={activeKey}
         tabList={tabs}

--- a/src/js/components/Scope/ScopedTitle.tsx
+++ b/src/js/components/Scope/ScopedTitle.tsx
@@ -13,6 +13,7 @@ import { useGetRouteTitleAndIcon } from '@/hooks/navigation';
 import { BentoRoute, TOP_LEVEL_ONLY_ROUTES } from '@/types/routes';
 import { getCurrentPage } from '@/utils/router';
 import CurrentPageHelpModal from '@/components/Util/CurrentPageHelpModal';
+import { useExtraBreadcrumb } from '@/features/ui/hooks';
 
 const breadcrumbRender: BreadcrumbProps['itemRender'] = (route, _params, routes, _paths) => {
   const isLast = route?.path === routes[routes.length - 1]?.path;
@@ -40,6 +41,8 @@ const ScopedTitle = () => {
     const k = `page_help.${currentPage}`;
     return k !== t(k);
   }, [t, currentPage]);
+
+  const extraBreadcrumb = useExtraBreadcrumb();
 
   useEffect(() => {
     // If the selected scope changes (likely from the scope select modal), auto-close the modal.
@@ -69,6 +72,10 @@ const ScopedTitle = () => {
       items.push({ title: currentPageTitle });
     }
 
+    if (extraBreadcrumb) {
+      items.push(extraBreadcrumb);
+    }
+
     return items;
   }, [
     i18n.language,
@@ -80,6 +87,7 @@ const ScopedTitle = () => {
     fixedDataset,
     currentPage,
     getRouteTitleAndIcon,
+    extraBreadcrumb,
   ]);
 
   useEffect(() => {

--- a/src/js/components/Scope/ScopedTitle.tsx
+++ b/src/js/components/Scope/ScopedTitle.tsx
@@ -29,7 +29,10 @@ const ScopedTitle = () => {
 
   const getRouteTitleAndIcon = useGetRouteTitleAndIcon();
   const currentPage = getCurrentPage();
-  const scopeSelectionEnabled = !(fixedProject && fixedDataset) && !TOP_LEVEL_ONLY_ROUTES.includes(currentPage);
+  const scopeSelectionEnabled =
+    !(fixedProject && fixedDataset) &&
+    !TOP_LEVEL_ONLY_ROUTES.includes(currentPage) &&
+    currentPage !== BentoRoute.Phenopackets;
   const [scopeSelectModalOpen, setScopeSelectModalOpen] = useState(false);
   const [helpModalOpen, setHelpModalOpen] = useState(false);
 
@@ -96,8 +99,6 @@ const ScopedTitle = () => {
     }
   }, [breadcrumbItems]);
 
-  const isPhenopacketView = currentPage === BentoRoute.Phenopackets;
-
   if (breadcrumbItems.length) {
     return (
       <>
@@ -106,7 +107,7 @@ const ScopedTitle = () => {
         <Flex className="scoped-title" align="center">
           <Breadcrumb className="scoped-title__breadcrumb" items={breadcrumbItems} itemRender={breadcrumbRender} />
           <Space>
-            {scopeSelectionEnabled && !isPhenopacketView && (
+            {scopeSelectionEnabled && (
               <Tooltip title={t('Change Scope')} placement="bottom">
                 <Button
                   color="default"

--- a/src/js/components/Util/ClinPhen/Excluded.tsx
+++ b/src/js/components/Util/ClinPhen/Excluded.tsx
@@ -18,7 +18,11 @@ const Excluded = ({ model }: { model: ExcludedModel }) => {
         {t('clinphen_generic.excluded')}:
       </Text>
       &nbsp; {t('clinphen_generic.found_absent')} &nbsp;
-      <Link href={`https://phenopacket-schema.readthedocs.io/en/2.0.0/${model}.html#excluded`}>
+      <Link
+        href={`https://phenopacket-schema.readthedocs.io/en/2.0.0/${model}.html#excluded`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         <LinkOutlined />
       </Link>
       )

--- a/src/js/components/Util/ClinPhen/Procedure.tsx
+++ b/src/js/components/Util/ClinPhen/Procedure.tsx
@@ -10,7 +10,7 @@ const Procedure = ({ procedure: p }: { procedure: ProcedureType | undefined }) =
   const items: ConditionalDescriptionItem[] = [
     {
       key: 'code',
-      label: 'biosample_expanded_row.code',
+      label: 'clinphen_generic.code',
       children: <OntologyTerm term={p.code} />,
     },
     {

--- a/src/js/components/Util/CustomTable.tsx
+++ b/src/js/components/Util/CustomTable.tsx
@@ -121,7 +121,8 @@ const CustomTable = <T extends object>({
       }}
       rowKey={rowKey}
       pagination={false}
-      bordered
+      bordered={true}
+      size="small"
     />
   );
 };

--- a/src/js/components/Util/CustomTable.tsx
+++ b/src/js/components/Util/CustomTable.tsx
@@ -6,8 +6,9 @@ import { useTranslatedTableColumnTitles } from '@/hooks/useTranslatedTableColumn
 import { useNotify } from '@/hooks/notifications';
 import { useTranslationFn } from '@/hooks';
 
-import type { WithVisible } from '@/types/util';
+import type { VisibilityFn, WithVisible } from '@/types/util';
 import { EXPANDED_QUERY_PARAM_KEY } from '@/constants/table';
+import { addVisibilityProperty } from '@/utils/tables';
 
 export interface CustomTableColumn<T> extends TableColumnType<T> {
   isEmpty?: (value: any, record?: T) => boolean; // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -16,12 +17,7 @@ export interface CustomTableColumn<T> extends TableColumnType<T> {
 
 export type CustomTableColumns<T> = CustomTableColumn<T>[];
 
-type VisibilityFn<T> = (record: T) => boolean;
 type RowKeyFn<T> = (record: T, index?: number) => string;
-
-function addVisibility<T>(items: T[], isVisible: VisibilityFn<T>): WithVisible<T>[] {
-  return items.map((item) => ({ ...item, isVisible: isVisible(item) }));
-}
 
 function serializeExpandedKeys(keys: string[]): string {
   return keys.join(',');
@@ -42,7 +38,7 @@ interface CustomTableProps<T> {
   dataSource: T[];
   columns: CustomTableColumns<T>;
   rowKey: string | RowKeyFn<WithVisible<T>>;
-  isDataKeyVisible: VisibilityFn<T>;
+  isRowExpandable: VisibilityFn<T>;
   expandedRowRender?: (record: T) => React.ReactNode;
   queryKey?: string;
 }
@@ -51,7 +47,7 @@ const CustomTable = <T extends object>({
   dataSource,
   columns,
   rowKey,
-  isDataKeyVisible,
+  isRowExpandable,
   expandedRowRender,
   queryKey = EXPANDED_QUERY_PARAM_KEY,
 }: CustomTableProps<T>) => {
@@ -66,7 +62,8 @@ const CustomTable = <T extends object>({
     return (record: WithVisible<T>) => String(record[rowKey as keyof WithVisible<T>]);
   }, [rowKey]);
 
-  const visibleData = useMemo(() => addVisibility(dataSource, isDataKeyVisible), [dataSource, isDataKeyVisible]);
+  // A bit hacky - we use isVisible as a key to represent "expandability" internally in this component:
+  const visibleData = useMemo(() => addVisibilityProperty(dataSource, isRowExpandable), [dataSource, isRowExpandable]);
 
   const translatedColumns = useTranslatedTableColumnTitles(columns) as CustomTableColumns<WithVisible<T>>;
   const processedColumns = useMemo(
@@ -114,6 +111,7 @@ const CustomTable = <T extends object>({
       dataSource={visibleData}
       expandable={{
         expandedRowRender,
+        // Here, isVisible means "is expandable", we're just using the WithVisible type internally:
         rowExpandable: (record) => record.isVisible,
         showExpandColumn: visibleData.some((r) => r.isVisible),
         expandedRowKeys: expandedKeys,

--- a/src/js/features/ui/hooks.ts
+++ b/src/js/features/ui/hooks.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import { useAppDispatch, useAppSelector } from '@/hooks';
+import { setExtraBreadcrumb } from './ui.store';
+
+export const useExtraBreadcrumb = () => useAppSelector((state) => state.ui.extraBreadcrumb);
+
+export const useSetExtraBreadcrumb = (title: string | undefined) => {
+  const dispatch = useAppDispatch();
+  useEffect(() => {
+    if (title) {
+      dispatch(setExtraBreadcrumb({ title }));
+    }
+
+    return () => {
+      dispatch(setExtraBreadcrumb(null));
+    };
+  }, [dispatch, title]);
+};

--- a/src/js/features/ui/ui.store.ts
+++ b/src/js/features/ui/ui.store.ts
@@ -1,0 +1,25 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import type { BreadcrumbItemType } from 'antd/es/breadcrumb/Breadcrumb';
+
+const storeName = 'ui';
+
+export type UIState = {
+  extraBreadcrumb: BreadcrumbItemType | null;
+};
+
+const initialState: UIState = {
+  extraBreadcrumb: null,
+};
+
+const ui = createSlice({
+  name: storeName,
+  initialState,
+  reducers: {
+    setExtraBreadcrumb: (state, { payload }: PayloadAction<BreadcrumbItemType | null>) => {
+      return { ...state, extraBreadcrumb: payload };
+    },
+  },
+});
+
+export const { setExtraBreadcrumb } = ui.actions;
+export default ui.reducer;

--- a/src/js/hooks/navigation.tsx
+++ b/src/js/hooks/navigation.tsx
@@ -43,7 +43,7 @@ export const useGetRouteTitleAndIcon = () => {
         case BentoRoute.BeaconNetwork:
           return ['Beacon Network', <ShareAltOutlined />];
         case BentoRoute.Phenopackets:
-          return ['Phenopackets', <SolutionOutlined />];
+          return ['entities.phenopacket_other', <SolutionOutlined />];
         default:
           console.error('Unknown page', routeId);
           return ['', null];

--- a/src/js/hooks/usePhenopacketTabs.tsx
+++ b/src/js/hooks/usePhenopacketTabs.tsx
@@ -37,7 +37,7 @@ export const usePhenopacketTabs = (phenopacket: Phenopacket | undefined) => {
       },
       {
         key: TabKeys.BIOSAMPLES,
-        label: t('entities.biosamples_many'),
+        label: t('entities.biosample_other'),
         children: phenopacket.biosamples ? <BiosampleView biosamples={phenopacket.biosamples} /> : null,
         disabled: !phenopacket.biosamples?.length,
       },

--- a/src/js/hooks/usePhenopacketTabs.tsx
+++ b/src/js/hooks/usePhenopacketTabs.tsx
@@ -31,7 +31,7 @@ export const usePhenopacketTabs = (phenopacket: Phenopacket | undefined) => {
     const allItems = [
       {
         key: TabKeys.SUBJECT,
-        label: t('tab_keys.subject'),
+        label: t('subject.subject'),
         children: phenopacket.subject ? <SubjectView subject={phenopacket.subject} /> : null,
         disabled: !phenopacket.subject,
       },

--- a/src/js/hooks/usePhenopacketTabs.tsx
+++ b/src/js/hooks/usePhenopacketTabs.tsx
@@ -15,7 +15,7 @@ import { TabKeys } from '@/types/PhenopacketView.types';
 import type { Phenopacket } from '@/types/clinPhen/phenopacket';
 import { useTranslationFn } from '@/hooks';
 
-export const usePhenopacketTabs = (phenopacket: Phenopacket) => {
+export const usePhenopacketTabs = (phenopacket: Phenopacket | undefined) => {
   const t = useTranslationFn();
   const navigate = useNavigate();
   const handleTabChange = useCallback(
@@ -27,60 +27,61 @@ export const usePhenopacketTabs = (phenopacket: Phenopacket) => {
 
   // TODO: Add Experiments
   const items: TabsProps['items'] = useMemo(() => {
+    if (!phenopacket) return [];
     const allItems = [
       {
         key: TabKeys.SUBJECT,
         label: t('tab_keys.subject'),
-        children: <SubjectView subject={phenopacket?.subject} />,
-        disabled: !phenopacket?.subject,
+        children: phenopacket.subject ? <SubjectView subject={phenopacket.subject} /> : null,
+        disabled: !phenopacket.subject,
       },
       {
         key: TabKeys.BIOSAMPLES,
         label: t('tab_keys.biosamples'),
-        children: phenopacket?.biosamples ? <BiosampleView biosamples={phenopacket?.biosamples} /> : null,
-        disabled: !phenopacket?.biosamples?.length,
+        children: phenopacket.biosamples ? <BiosampleView biosamples={phenopacket.biosamples} /> : null,
+        disabled: !phenopacket.biosamples?.length,
       },
       {
         key: TabKeys.MEASUREMENTS,
         label: t('tab_keys.measurements'),
-        children: phenopacket?.measurements ? <MeasurementsView measurements={phenopacket?.measurements} /> : null,
-        disabled: !phenopacket?.measurements?.length,
+        children: phenopacket.measurements ? <MeasurementsView measurements={phenopacket.measurements} /> : null,
+        disabled: !phenopacket.measurements?.length,
       },
       {
         key: TabKeys.PHENOTYPIC_FEATURES,
         label: t('tab_keys.phenotypic_features'),
-        children: phenopacket?.phenotypic_features ? (
+        children: phenopacket.phenotypic_features ? (
           <PhenotypicFeaturesView features={phenopacket.phenotypic_features} />
         ) : null,
-        disabled: !phenopacket?.phenotypic_features?.length,
+        disabled: !phenopacket.phenotypic_features?.length,
       },
       {
         key: TabKeys.DISEASES,
         label: t('tab_keys.diseases'),
-        children: phenopacket?.diseases ? <DiseasesView diseases={phenopacket.diseases} /> : null,
-        disabled: !phenopacket?.diseases?.length,
+        children: phenopacket.diseases ? <DiseasesView diseases={phenopacket.diseases} /> : null,
+        disabled: !phenopacket.diseases?.length,
       },
       {
         key: TabKeys.INTERPRETATIONS,
         label: t('tab_keys.interpretations'),
-        children: phenopacket?.interpretations ? (
+        children: phenopacket.interpretations ? (
           <InterpretationsView interpretations={phenopacket.interpretations} />
         ) : null,
-        disabled: !phenopacket?.interpretations?.length,
+        disabled: !phenopacket.interpretations?.length,
       },
       {
         key: TabKeys.MEDICAL_ACTIONS,
         label: t('tab_keys.medical_actions'),
-        children: phenopacket?.medical_actions ? (
+        children: phenopacket.medical_actions ? (
           <MedicalActionsView medicalActions={phenopacket.medical_actions} />
         ) : null,
-        disabled: !phenopacket?.medical_actions?.length,
+        disabled: !phenopacket.medical_actions?.length,
       },
       {
         key: TabKeys.ONTOLOGIES,
         label: t('tab_keys.ontologies'),
-        children: <OntologiesView resources={phenopacket?.meta_data?.resources} />,
-        disabled: !phenopacket?.meta_data?.resources?.length,
+        children: <OntologiesView resources={phenopacket.meta_data?.resources} />,
+        disabled: !phenopacket.meta_data?.resources?.length,
       },
     ];
     return allItems.filter((item) => !item.disabled);

--- a/src/js/hooks/usePhenopacketTabs.tsx
+++ b/src/js/hooks/usePhenopacketTabs.tsx
@@ -37,7 +37,7 @@ export const usePhenopacketTabs = (phenopacket: Phenopacket | undefined) => {
       },
       {
         key: TabKeys.BIOSAMPLES,
-        label: t('tab_keys.biosamples'),
+        label: t('entities.biosamples_many'),
         children: phenopacket.biosamples ? <BiosampleView biosamples={phenopacket.biosamples} /> : null,
         disabled: !phenopacket.biosamples?.length,
       },

--- a/src/js/store.ts
+++ b/src/js/store.ts
@@ -14,6 +14,7 @@ import beaconReducer from './features/beacon/beacon.store';
 import beaconNetworkReducer from './features/beacon/network.store';
 import metadataReducer from '@/features/metadata/metadata.store';
 import reference from '@/features/reference/reference.store';
+import ui from '@/features/ui/ui.store';
 import { getValue, saveValue } from './utils/localStorage';
 
 interface PersistedState {
@@ -41,6 +42,7 @@ export const store = configureStore({
     beaconNetwork: beaconNetworkReducer,
     metadata: metadataReducer,
     reference,
+    ui,
   },
   preloadedState: persistedState,
 });

--- a/src/js/types/clinPhen/phenopacket.ts
+++ b/src/js/types/clinPhen/phenopacket.ts
@@ -15,7 +15,7 @@ import type { File } from './file';
 
 export interface Phenopacket extends ExtraPropertiesEntity, TimestampedEntity {
   id: string;
-  subject: Individual;
+  subject?: Individual;
   phenotypic_features?: PhenotypicFeature[];
   measurements?: Measurement[];
   biosamples?: Biosample[];

--- a/src/js/types/util.ts
+++ b/src/js/types/util.ts
@@ -18,3 +18,5 @@ export interface TimestampedEntity {
 export type WithVisible<T> = T & {
   isVisible: boolean;
 };
+
+export type VisibilityFn<T> = (record: T) => boolean;

--- a/src/js/utils/tables.ts
+++ b/src/js/utils/tables.ts
@@ -1,7 +1,5 @@
-import type { WithVisible } from '@/types/util';
+import type { VisibilityFn, WithVisible } from '@/types/util';
 
-export const addVisibilityProperty = <T>(r: T[], visibilityFunc: (r: T) => boolean): WithVisible<T>[] =>
-  r.map((item) => ({
-    ...item,
-    isVisible: visibilityFunc(item),
-  }));
+export function addVisibilityProperty<T>(items: T[], visibilityFn: VisibilityFn<T>): WithVisible<T>[] {
+  return items.map((item) => ({ ...item, isVisible: visibilityFn(item) }));
+}

--- a/src/public/locales/en/default_translation_en.json
+++ b/src/public/locales/en/default_translation_en.json
@@ -358,6 +358,7 @@
     "reference": "Reference"
   },
   "subject": {
+    "subject": "Subject",
     "age": "Age",
     "status": "Status",
     "time_of_death": "Time of Death",
@@ -372,7 +373,6 @@
     "taxonomy": "Taxonomy"
   },
   "tab_keys": {
-    "subject": "Subject",
     "measurements": "Measurements",
     "phenotypic_features": "Phenotypic Features",
     "diseases": "Diseases",

--- a/src/public/locales/en/default_translation_en.json
+++ b/src/public/locales/en/default_translation_en.json
@@ -207,7 +207,8 @@
   },
   "clinphen_generic": {
     "excluded": "Excluded",
-    "found_absent": "Found to be absent"
+    "found_absent": "Found to be absent",
+    "code": "Code"
   },
   "biosample_expanded_row": {
     "description": "Description",
@@ -217,7 +218,6 @@
     "histological_diagnosis": "Histological diagnosis",
     "pathological_stage": "Pathological stage",
     "procedure": "Procedure",
-    "code": "Code",
     "body_site": "Body site",
     "performed": "Performed",
     "taxonomy": "Taxonomy",

--- a/src/public/locales/en/default_translation_en.json
+++ b/src/public/locales/en/default_translation_en.json
@@ -372,7 +372,6 @@
   },
   "tab_keys": {
     "subject": "Subject",
-    "biosamples": "Biosamples",
     "measurements": "Measurements",
     "phenotypic_features": "Phenotypic Features",
     "diseases": "Diseases",

--- a/src/public/locales/en/default_translation_en.json
+++ b/src/public/locales/en/default_translation_en.json
@@ -258,6 +258,7 @@
     "progress_status": "Progress Status",
     "summary": "Summary",
     "disease": "Disease",
+    "disease_diagnosis": "Disease Diagnosis",
     "variant_interpretation": "Variant Interpretation",
     "gene_descriptor": "Gene Descriptor",
     "subject_or_biosample_id": "Subject or Biosample ID",

--- a/src/public/locales/fr/default_translation_fr.json
+++ b/src/public/locales/fr/default_translation_fr.json
@@ -263,6 +263,7 @@
     "progress_status": "Statut de progression",
     "summary": "Résumé",
     "disease": "Maladie",
+    "disease_diagnosis": "Diagnostic de maladie",
     "variant_interpretation": "Interprétation du variant",
     "gene_descriptor": "Descripteur de gène",
     "subject_or_biosample_id": "ID du sujet ou de l'échantillon biologique",

--- a/src/public/locales/fr/default_translation_fr.json
+++ b/src/public/locales/fr/default_translation_fr.json
@@ -363,6 +363,7 @@
     "reference": "Référence"
   },
   "subject": {
+    "subject": "Sujet",
     "age": "Âge",
     "status": "Statut",
     "time_of_death": "Date du décès",
@@ -377,7 +378,6 @@
     "taxonomy": "Taxonomie"
   },
   "tab_keys": {
-    "subject": "Sujet",
     "measurements": "Mesures",
     "phenotypic_features": "Caractéristiques phénotypiques",
     "diseases": "Maladies",

--- a/src/public/locales/fr/default_translation_fr.json
+++ b/src/public/locales/fr/default_translation_fr.json
@@ -377,7 +377,6 @@
   },
   "tab_keys": {
     "subject": "Sujet",
-    "biosamples": "Échantillons biologiques",
     "measurements": "Mesures",
     "phenotypic_features": "Caractéristiques phénotypiques",
     "diseases": "Maladies",

--- a/src/public/locales/fr/default_translation_fr.json
+++ b/src/public/locales/fr/default_translation_fr.json
@@ -212,7 +212,8 @@
   },
   "clinphen_generic": {
     "excluded": "Exclu",
-    "found_absent": "Trouvé absent"
+    "found_absent": "Trouvé absent",
+    "code": "Code"
   },
   "biosample_expanded_row": {
     "description": "Description",
@@ -222,7 +223,6 @@
     "histological_diagnosis": "Diagnostic histologique",
     "pathological_stage": "Stade pathologique",
     "procedure": "Procédure",
-    "code": "Code",
     "body_site": "Site du corps",
     "performed": "Effectué",
     "taxonomy": "Taxonomie",

--- a/src/styles.css
+++ b/src/styles.css
@@ -39,6 +39,7 @@ body {
 .cursor-pointer { cursor: pointer; }
 .select-none { user-select: none; }
 .font-mono { font-family: ui-monospace, monospace; }
+.font-normal { font-weight: normal; }
 .text-center { text-align: center; }
 
 /* custom, tailwind-esque */

--- a/src/styles.css
+++ b/src/styles.css
@@ -363,6 +363,19 @@ h3.search-sub-form-title:not(.focused) .search-sub-form-title__inner > span.shou
 
 /* END search */
 
+/* BEGIN phenopacket view */
+
+#subject-view .ant-descriptions-item-label {
+  /* Align split line vertically in all descriptions */
+  width: 30vw;
+}
+
+tr.ant-table-expanded-row .ant-descriptions-item-content .ant-descriptions > .ant-descriptions-view > table {
+  width: auto;
+}
+
+/* END phenopacket view */
+
 
 @media (min-width: 1050px) and (max-width: 1550px) {
   .dataset-provenance-card-grid {
@@ -409,9 +422,4 @@ h3.search-sub-form-title:not(.focused) .search-sub-form-title__inner > span.shou
     /* For small screens, reset group gap size */
     gap: 16px;
   }
-}
-
-#subject-view .ant-descriptions-item-label {
-  /* Align split line vertically in all descriptions */
-  width: 30vw;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -39,7 +39,6 @@ body {
 .cursor-pointer { cursor: pointer; }
 .select-none { user-select: none; }
 .font-mono { font-family: ui-monospace, monospace; }
-.font-normal { font-weight: normal; }
 .text-center { text-align: center; }
 
 /* custom, tailwind-esque */


### PR DESCRIPTION
* More compact tables/descriptions
* Add missing `gender` property to subject view
* Higher information density in medical actions/interpretations tables by showing some nested properties in the main table
* "Nice" title for phenopacket vs. ID (subject ID or biosample ID list)
* Some translation fixes
* Typing fixes