### PR TITLE
Fixed rule call sequence

### DIFF
--- a/src/js/components/BentoAppRouter.tsx
+++ b/src/js/components/BentoAppRouter.tsx
@@ -68,6 +68,10 @@ const ScopedRoute = () => {
       (!projectId && !datasetId && isFixedProjectAndDataset)
     ) {
       dispatch(selectScope(valid.scope)); // Also marks scope as set
+
+      // Conditions where we need to reload "config" (which really is closer to rules for search):
+      //  - scope was set (need to load for the first time)
+      //  - config was invalidated (scope or authorization changed)
       dispatch(makeGetConfigRequest());
       return;
     }

--- a/src/js/components/BentoAppRouter.tsx
+++ b/src/js/components/BentoAppRouter.tsx
@@ -4,7 +4,7 @@ import { useAutoAuthenticate, useIsAuthenticated } from 'bento-auth-js';
 import { useAppDispatch } from '@/hooks';
 
 import { clearIndividualCache } from '@/features/clinPhen/clinPhen.store';
-import { invalidateConfig, makeGetServiceInfoRequest } from '@/features/config/config.store';
+import { invalidateConfig, makeGetServiceInfoRequest, makeGetConfigRequest } from '@/features/config/config.store';
 import { makeGetAboutRequest } from '@/features/content/content.store';
 import { getBeaconConfig, getBeaconFilters } from '@/features/beacon/beacon.store';
 import { getBeaconNetworkConfig } from '@/features/beacon/network.store';
@@ -68,6 +68,7 @@ const ScopedRoute = () => {
       (!projectId && !datasetId && isFixedProjectAndDataset)
     ) {
       dispatch(selectScope(valid.scope)); // Also marks scope as set
+      dispatch(makeGetConfigRequest());
       return;
     }
 

--- a/src/js/features/config/hooks.ts
+++ b/src/js/features/config/hooks.ts
@@ -1,22 +1,7 @@
-import { useEffect } from 'react';
-import { useAppDispatch, useAppSelector } from '@/hooks';
-import { makeGetConfigRequest } from '@/features/config/config.store';
-import { useSelectedScope } from '@/features/metadata/hooks';
+import { useAppSelector } from '@/hooks';
 
 export const useConfig = () => {
-  const dispatch = useAppDispatch();
-  const { scopeSet } = useSelectedScope();
   const { configStatus, configIsInvalid, countThreshold, maxQueryParameters } = useAppSelector((state) => state.config);
-
-  // Conditions where we need to reload "config" (which really is closer to rules for search):
-  //  - scope was set (need to load for the first time)
-  //  - config was invalidated (scope or authorization changed)
-  useEffect(() => {
-    if (scopeSet) {
-      // dispatch action if scope is set and/or the state is invalidated and then this hook is called.
-      dispatch(makeGetConfigRequest());
-    }
-  }, [dispatch, scopeSet, configIsInvalid]);
 
   return { configStatus, configIsInvalid, countThreshold, maxQueryParameters };
 };


### PR DESCRIPTION
Fixed the following bug: bento public behaves incorrectly when there are multiple projects. In particular it erroneously checks the top-level `/public_rules`  in situations where it should check `/public_rules/<project_id>` instead.