### PR TITLE
remove stale pagination params on change

### DIFF
--- a/src/js/components/Search/SearchResultsTablePage.tsx
+++ b/src/js/components/Search/SearchResultsTablePage.tsx
@@ -30,7 +30,11 @@ import type {
 import { BentoRoute } from '@/types/routes';
 
 import { scopeSelectionEqual } from '@/features/metadata/utils';
-import { bentoKatsuEntityToResultsDataEntity, buildQueryParamsUrl } from '@/features/search/utils';
+import {
+  bentoKatsuEntityToResultsDataEntity,
+  buildQueryParamsUrl,
+  queryParamsWithoutKey,
+} from '@/features/search/utils';
 import { setEquals } from '@/utils/sets';
 
 import DatasetProvenanceModal from '@/components/Provenance/DatasetProvenanceModal';
@@ -400,10 +404,7 @@ const SearchResultsTable = <T extends ViewableDiscoveryMatchObject>({
               }
               navigateToSameScopeUrl(
                 buildQueryParamsUrl(BentoRoute.Overview, [
-                  //remove stale params
-                  ...allQueryParams.filter(
-                    (p) => p.length > 0 && !(p[0] == TABLE_PAGE_QUERY_PARAM || p[0] == TABLE_PAGE_SIZE_QUERY_PARAM)
-                  ),
+                  ...queryParamsWithoutKey(allQueryParams, [TABLE_PAGE_QUERY_PARAM, TABLE_PAGE_SIZE_QUERY_PARAM]),
 
                   // AntD page is 1-indexed, discovery match page is 0-indexed:
                   [TABLE_PAGE_QUERY_PARAM, (newPage - 1).toString()],

--- a/src/js/components/Search/SearchResultsTablePage.tsx
+++ b/src/js/components/Search/SearchResultsTablePage.tsx
@@ -400,7 +400,11 @@ const SearchResultsTable = <T extends ViewableDiscoveryMatchObject>({
               }
               navigateToSameScopeUrl(
                 buildQueryParamsUrl(BentoRoute.Overview, [
-                  ...allQueryParams,
+                  //remove stale params
+                  ...allQueryParams.filter(
+                    (p) => p.length > 0 && !(p[0] == TABLE_PAGE_QUERY_PARAM || p[0] == TABLE_PAGE_SIZE_QUERY_PARAM)
+                  ),
+
                   // AntD page is 1-indexed, discovery match page is 0-indexed:
                   [TABLE_PAGE_QUERY_PARAM, (newPage - 1).toString()],
                   [TABLE_PAGE_SIZE_QUERY_PARAM, newPageSize.toString()],


### PR DESCRIPTION
Bugfix for Redmine #2794

Query params are now stored as array of arrays instead of object, so the expected pattern of spreading the old params and adding new ones no longer works (this just gives you the same param twice with two different values). 

We could revisit objects vs nested arrays at some point, for now here is a one-line fix for broken pagination params, 