### PR TITLE
chore: hide last ingestion info in catalogue mode

### DIFF
--- a/src/js/components/Overview/OverviewChartDashboard.tsx
+++ b/src/js/components/Overview/OverviewChartDashboard.tsx
@@ -31,6 +31,7 @@ import { useTranslationFn } from '@/hooks';
 import { useSearchRouterAndHandler } from '@/hooks/useSearchRouterAndHandler';
 import { useSelectedDataset, useSelectedProject, useSelectedScope } from '@/features/metadata/hooks';
 import { useSearchQuery, useSearchableFields } from '@/features/search/hooks';
+import { useIsInCatalogueMode } from '@/hooks/navigation';
 
 const saveScopeOverviewToLS = (scope: DiscoveryScope, sections: Sections) => {
   saveValue(generateLSChartDataKey(scope), convertSequenceAndDisplayData(sections));
@@ -44,6 +45,7 @@ const OverviewChartDashboard = () => {
   const { scope } = useSelectedScope();
   const selectedProject = useSelectedProject();
   const selectedDataset = useSelectedDataset();
+  const catalogueMode = useIsInCatalogueMode();
 
   // This is essentially a large effect hook with a few dependencies, which processes (and rewrites if needed) the query
   // URL and dispatches discovery actions for fetching overview/query response data.
@@ -153,7 +155,7 @@ const OverviewChartDashboard = () => {
           </div>
         ))}
 
-        {!noDataInScope && <LastIngestionInfo />}
+        {!noDataInScope && !catalogueMode && <LastIngestionInfo />}
       </Flex>
 
       <ManageChartsDrawer onManageDrawerClose={onManageChartsClose} manageDrawerVisible={drawerVisible} />


### PR DESCRIPTION
as discussed in slack - hide last ingestion info when we're not in a single-project node.