### PR TITLE
fix biosample count total in beacon network results

### DIFF
--- a/src/js/features/beacon/utils.ts
+++ b/src/js/features/beacon/utils.ts
@@ -52,7 +52,7 @@ export const computeNetworkResults = (responses: BeaconNetworkResponses) => {
 
   Object.values(responses).forEach(({ results }) => {
     overview.individualCount += results.individualCount ?? 0;
-    overview.biosampleCount += results.experimentCount ?? 0;
+    overview.biosampleCount += results.biosampleCount ?? 0;
     overview.experimentCount += results.experimentCount ?? 0;
     overview.biosampleChartData = mergeCharts(overview.biosampleChartData, results.biosampleChartData ?? []);
     overview.experimentChartData = mergeCharts(overview.experimentChartData, results.experimentChartData ?? []);


### PR DESCRIPTION
Fix biosample counts for beacon network results, it was erroneously just repeating the experiment counts. 