### PR TITLE
feat: hide sidebar/chart/response UI with 0-data projects/datasets

### DIFF
--- a/src/js/components/Overview/OverviewChartDashboard.tsx
+++ b/src/js/components/Overview/OverviewChartDashboard.tsx
@@ -20,10 +20,9 @@ import DatasetProvenance from '@/components/Provenance/DatasetProvenance';
 
 import { useTranslationFn } from '@/hooks';
 import { useSearchRouterAndHandler } from '@/hooks/useSearchRouterAndHandler';
-import { useSelectedDataset, useSelectedProject, useSelectedScope } from '@/features/metadata/hooks';
+import { useSelectedDataset, useSelectedProject, useSelectedScope, useScopeHasData } from '@/features/metadata/hooks';
 import { useSearchQuery, useSearchableFields } from '@/features/search/hooks';
 import { useIsInCatalogueMode } from '@/hooks/navigation';
-import { emptyCounts } from '@/utils/counts';
 
 const saveScopeOverviewToLS = (scope: DiscoveryScope, sections: Sections) => {
   saveValue(generateLSChartDataKey(scope), convertSequenceAndDisplayData(sections));
@@ -48,14 +47,12 @@ const OverviewChartDashboard = () => {
   // Lazy-loading hooks means this is loaded only if OverviewChartDashboard is rendered:
   const searchableFields = useSearchableFields();
 
-  // If we have no entities with data confirmed, don't bother showing charts (or last ingested details)
-  const noDataInDataset = !!selectedDataset && emptyCounts(selectedDataset.counts_by_entity);
-  const noDataInProject = !!selectedProject && emptyCounts(selectedProject.counts);
-  const noDataInScope = noDataInDataset || noDataInProject;
+  const scopeHasData = useScopeHasData();
 
-  const displayedSections = noDataInScope
-    ? []
-    : sections.filter(({ charts }) => charts.findIndex(({ isDisplayed }) => isDisplayed) !== -1);
+  // If we have no entities with data confirmed, don't bother showing charts (or last ingested details)
+  const displayedSections = scopeHasData
+    ? sections.filter(({ charts }) => charts.findIndex(({ isDisplayed }) => isDisplayed) !== -1)
+    : [];
 
   const onManageChartsOpen = useCallback(() => setDrawerVisible(true), []);
   const onManageChartsClose = useCallback(() => {
@@ -80,7 +77,7 @@ const OverviewChartDashboard = () => {
 
   return (
     <>
-      <Flex vertical={true} gap={24} className={clsx('container', { 'margin-auto': noDataInScope || noDataInDataset })}>
+      <Flex vertical={true} gap={24} className={clsx('container', { 'margin-auto': !scopeHasData })}>
         <div className="dashboard-tabs">
           {pageTabItems.length > 1 && (
             <Tabs
@@ -104,7 +101,7 @@ const OverviewChartDashboard = () => {
             "NOT ENOUGH DATA" message / "NO DATA" empty component. This way, we get a sort of "catalogue detail" view,
             allowing provenance-only datasets to be rendered nicely.
         */}
-        {!noDataInScope && <CountsAndResults />}
+        {scopeHasData && <CountsAndResults />}
 
         {selectedProject && !scope.dataset && selectedProject.datasets_v2.length ? (
           // If we have a project with at least one dataset, show a dataset mini-catalogue in the project overview
@@ -121,14 +118,14 @@ const OverviewChartDashboard = () => {
           </div>
         ))}
 
-        {!noDataInScope && !catalogueMode && <LastIngestionInfo />}
+        {scopeHasData && !catalogueMode && <LastIngestionInfo />}
       </Flex>
 
       <ManageChartsDrawer onManageDrawerClose={onManageChartsClose} manageDrawerVisible={drawerVisible} />
 
       <FloatButton.Group className="float-btn-pos">
         <FloatButton.BackTop target={() => document.getElementById('content-layout')!} />
-        {!noDataInScope && (
+        {scopeHasData && (
           <FloatButton
             type="primary"
             icon={<AppstoreAddOutlined rotate={270} />}

--- a/src/js/components/Overview/OverviewChartDashboard.tsx
+++ b/src/js/components/Overview/OverviewChartDashboard.tsx
@@ -7,7 +7,6 @@ import { convertSequenceAndDisplayData, generateLSChartDataKey, saveValue } from
 
 import type { Sections } from '@/types/data';
 import type { DiscoveryScope } from '@/features/metadata/metadata.store';
-import { RequestStatus } from '@/types/requests';
 
 import { WAITING_STATES } from '@/constants/requests';
 
@@ -24,6 +23,7 @@ import { useSearchRouterAndHandler } from '@/hooks/useSearchRouterAndHandler';
 import { useSelectedDataset, useSelectedProject, useSelectedScope } from '@/features/metadata/hooks';
 import { useSearchQuery, useSearchableFields } from '@/features/search/hooks';
 import { useIsInCatalogueMode } from '@/hooks/navigation';
+import { emptyCounts } from '@/utils/counts';
 
 const saveScopeOverviewToLS = (scope: DiscoveryScope, sections: Sections) => {
   saveValue(generateLSChartDataKey(scope), convertSequenceAndDisplayData(sections));
@@ -43,13 +43,15 @@ const OverviewChartDashboard = () => {
   // URL and dispatches discovery actions for fetching overview/query response data.
   useSearchRouterAndHandler();
 
-  const { discoveryStatus, sections, resultCountsByDataset, uiHints } = useSearchQuery();
+  const { discoveryStatus, sections, resultCountsByDataset } = useSearchQuery();
 
   // Lazy-loading hooks means this is loaded only if OverviewChartDashboard is rendered:
   const searchableFields = useSearchableFields();
 
   // If we have no entities with data confirmed, don't bother showing charts (or last ingested details)
-  const noDataInScope = uiHints.status === RequestStatus.Fulfilled && uiHints.data.entities_with_data.length === 0;
+  const noDataInDataset = !!selectedDataset && emptyCounts(selectedDataset.counts_by_entity);
+  const noDataInProject = !!selectedProject && emptyCounts(selectedProject.counts);
+  const noDataInScope = noDataInDataset || noDataInProject;
 
   const displayedSections = noDataInScope
     ? []
@@ -78,7 +80,7 @@ const OverviewChartDashboard = () => {
 
   return (
     <>
-      <Flex vertical={true} gap={24} className="container">
+      <Flex vertical={true} gap={24} className={clsx('container', { 'margin-auto': noDataInScope || noDataInDataset })}>
         <div className="dashboard-tabs">
           {pageTabItems.length > 1 && (
             <Tabs
@@ -97,7 +99,12 @@ const OverviewChartDashboard = () => {
           ) : null}
         </div>
 
-        <CountsAndResults />
+        {/*
+            If we're in a scope with no data at all, don't bother rendering the
+            "NOT ENOUGH DATA" message / "NO DATA" empty component. This way, we get a sort of "catalogue detail" view,
+            allowing provenance-only datasets to be rendered nicely.
+        */}
+        {!noDataInScope && <CountsAndResults />}
 
         {selectedProject && !scope.dataset && selectedProject.datasets_v2.length ? (
           // If we have a project with at least one dataset, show a dataset mini-catalogue in the project overview
@@ -121,12 +128,14 @@ const OverviewChartDashboard = () => {
 
       <FloatButton.Group className="float-btn-pos">
         <FloatButton.BackTop target={() => document.getElementById('content-layout')!} />
-        <FloatButton
-          type="primary"
-          icon={<AppstoreAddOutlined rotate={270} />}
-          tooltip={t('Manage Charts')}
-          onClick={onManageChartsOpen}
-        />
+        {!noDataInScope && (
+          <FloatButton
+            type="primary"
+            icon={<AppstoreAddOutlined rotate={270} />}
+            tooltip={t('Manage Charts')}
+            onClick={onManageChartsOpen}
+          />
+        )}
       </FloatButton.Group>
     </>
   );

--- a/src/js/components/Util/DefaultLayout.tsx
+++ b/src/js/components/Util/DefaultLayout.tsx
@@ -10,12 +10,13 @@ import SiteFooter from '@/components/SiteFooter';
 import PageHeader from '@/components/PageHeader';
 import PcglFooter from '@/components/Pcgl/PcglFooter';
 import ScopedTitle from '@/components/Scope/ScopedTitle';
-import { useSelectedScope } from '@/features/metadata/hooks';
+import { useSelectedDataset, useSelectedProject, useSelectedScope } from '@/features/metadata/hooks';
 import { useIsInCatalogueMode, useSidebarMenuItems } from '@/hooks/navigation';
 import { useTitleBreadcrumbItems } from '@/hooks/useTitleBreadcrumbItems';
 import { PCGL_MODE } from '@/config';
 import { BentoRoute } from '@/types/routes';
 import { getCurrentPage } from '@/utils/router';
+import { emptyCounts } from '@/utils/counts';
 
 const { Content } = Layout;
 const { useBreakpoint } = Grid;
@@ -26,6 +27,8 @@ const DefaultLayout = () => {
 
   const catalogueMode = useIsInCatalogueMode();
   const { scopeSet, scope } = useSelectedScope();
+  const selectedProject = useSelectedProject();
+  const selectedDataset = useSelectedDataset();
 
   const menuItems = useSidebarMenuItems();
   const [collapsed, setCollapsed] = useState(true);
@@ -36,7 +39,11 @@ const DefaultLayout = () => {
   const sidebarOverlay = !breakpoints.lg;
   const sidebarOverlayShown = sidebarOverlay && !collapsed;
   // TODO: enable sidebar with catalogue when catalogue filtering/search is hooked up
-  const sidebarHidden = page !== 'overview' || isCatalogue;
+  const sidebarHidden =
+    page !== 'overview' ||
+    isCatalogue ||
+    (!!selectedProject && emptyCounts(selectedProject.counts)) ||
+    (!!selectedDataset && emptyCounts(selectedDataset.counts_by_entity));
 
   const showSidebarToggle = sidebarOverlay && page === 'overview';
 
@@ -91,7 +98,7 @@ const DefaultLayout = () => {
                 aria-hidden
               />
             ) : null}
-            <Content>
+            <Content style={{ minHeight: 500 }}>
               <Outlet />
             </Content>
           </Layout>

--- a/src/js/components/Util/DefaultLayout.tsx
+++ b/src/js/components/Util/DefaultLayout.tsx
@@ -10,13 +10,12 @@ import SiteFooter from '@/components/SiteFooter';
 import PageHeader from '@/components/PageHeader';
 import PcglFooter from '@/components/Pcgl/PcglFooter';
 import ScopedTitle from '@/components/Scope/ScopedTitle';
-import { useSelectedDataset, useSelectedProject, useSelectedScope } from '@/features/metadata/hooks';
+import { useSelectedScope, useScopeHasData } from '@/features/metadata/hooks';
 import { useIsInCatalogueMode, useSidebarMenuItems } from '@/hooks/navigation';
 import { useTitleBreadcrumbItems } from '@/hooks/useTitleBreadcrumbItems';
 import { PCGL_MODE } from '@/config';
 import { BentoRoute } from '@/types/routes';
 import { getCurrentPage } from '@/utils/router';
-import { emptyCounts } from '@/utils/counts';
 
 const { Content } = Layout;
 const { useBreakpoint } = Grid;
@@ -27,8 +26,7 @@ const DefaultLayout = () => {
 
   const catalogueMode = useIsInCatalogueMode();
   const { scopeSet, scope } = useSelectedScope();
-  const selectedProject = useSelectedProject();
-  const selectedDataset = useSelectedDataset();
+  const scopeHasData = useScopeHasData();
 
   const menuItems = useSidebarMenuItems();
   const [collapsed, setCollapsed] = useState(true);
@@ -39,11 +37,7 @@ const DefaultLayout = () => {
   const sidebarOverlay = !breakpoints.lg;
   const sidebarOverlayShown = sidebarOverlay && !collapsed;
   // TODO: enable sidebar with catalogue when catalogue filtering/search is hooked up
-  const sidebarHidden =
-    page !== 'overview' ||
-    isCatalogue ||
-    (!!selectedProject && emptyCounts(selectedProject.counts)) ||
-    (!!selectedDataset && emptyCounts(selectedDataset.counts_by_entity));
+  const sidebarHidden = page !== 'overview' || isCatalogue || (!isCatalogue && !scopeHasData);
 
   const showSidebarToggle = sidebarOverlay && page === 'overview';
 

--- a/src/js/features/metadata/hooks.ts
+++ b/src/js/features/metadata/hooks.ts
@@ -3,6 +3,7 @@ import { makeProjectDatasetResource, makeProjectResource, type Resource, RESOURC
 import { useAppSelector } from '@/hooks';
 import type { Project } from '@/types/metadata';
 import type { Dataset } from '@/types/dataset';
+import type { KatsuEntityCountsOrBooleans } from '@/types/entities';
 
 export const useMetadata = () => useAppSelector((state) => state.metadata);
 
@@ -53,5 +54,23 @@ export const useSelectedScopeTitles = () => {
         : null,
     }),
     [selectedProject, scope]
+  );
+};
+
+const _nonEmptyCounts = (c: KatsuEntityCountsOrBooleans | null | undefined) => {
+  const values = Object.values(c ?? {});
+  if (values.length === 0) return false;
+  return values.some((c) => !!c);
+};
+
+export const useScopeHasData = () => {
+  const selectedProject = useSelectedProject();
+  const selectedDataset = useSelectedDataset();
+
+  return useMemo(
+    () =>
+      (!!selectedDataset && _nonEmptyCounts(selectedDataset.counts_by_entity)) ||
+      (!!selectedProject && _nonEmptyCounts(selectedProject.counts)),
+    [selectedProject, selectedDataset]
   );
 };

--- a/src/js/utils/counts.ts
+++ b/src/js/utils/counts.ts
@@ -1,6 +1,0 @@
-import type { KatsuEntityCountsOrBooleans } from '@/types/entities';
-
-export const emptyCounts = (c: KatsuEntityCountsOrBooleans | null | undefined) => {
-  const values = Object.values(c ?? {});
-  return values.length === 0 || values.every((c) => !c);
-};

--- a/src/js/utils/counts.ts
+++ b/src/js/utils/counts.ts
@@ -1,0 +1,6 @@
+import type { KatsuEntityCountsOrBooleans } from '@/types/entities';
+
+export const emptyCounts = (c: KatsuEntityCountsOrBooleans | null | undefined) => {
+  const values = Object.values(c ?? {});
+  return values.length === 0 || values.every((c) => !c);
+};


### PR DESCRIPTION
it's a bit ugly to show sidebar/manage-charts/"no data available" for datasets where we already *know* there isn't any data. instead, we could use this as a dataset provenance display for datasets where we may not want to ingest anything in yet.

this will look better once the new provenance display is ready, so concerns about the amount of empty space in the 'about' section on the dataset won't be relevant for the final release for this version.