### PR TITLE
refactor: unify datasets field on Project (drop _v2 suffix)

### DIFF
--- a/src/js/components/Overview/OverviewChartDashboard.tsx
+++ b/src/js/components/Overview/OverviewChartDashboard.tsx
@@ -103,10 +103,10 @@ const OverviewChartDashboard = () => {
         */}
         {scopeHasData && <CountsAndResults />}
 
-        {selectedProject && !scope.dataset && selectedProject.datasets_v2.length ? (
+        {selectedProject && !scope.dataset && selectedProject.datasets.length ? (
           // If we have a project with at least one dataset, show a dataset mini-catalogue in the project overview
           <OverviewDatasets
-            datasets={selectedProject.datasets_v2}
+            datasets={selectedProject.datasets}
             parentProjectID={selectedProject.identifier}
             countsByDataset={resultCountsByDataset}
           />

--- a/src/js/components/Provenance/Catalogue/CatalogueCard.tsx
+++ b/src/js/components/Provenance/Catalogue/CatalogueCard.tsx
@@ -49,7 +49,7 @@ const CatalogueCard = ({ project }: { project: Project }) => {
 
   const isSmallScreen = useSmallScreen();
 
-  const { datasets_v2: datasets, created, updated, title, description, identifier, counts } = project;
+  const { datasets, created, updated, title, description, identifier, counts } = project;
 
   const { selectedKeywords, extraKeywords, extraKeywordCount } = useMemo(() => {
     // TODO: render OntologyTerm keywords with ID + label instead of flattening to string

--- a/src/js/components/Provenance/DatasetProvenance.tsx
+++ b/src/js/components/Provenance/DatasetProvenance.tsx
@@ -89,7 +89,7 @@ const StakeholdersTable = ({ stakeholders }: { stakeholders: PersonOrOrganizatio
 
 // ---- Publications ----
 
-const PublicationsTableV2 = ({ publications }: { publications: Publication[] }) => {
+const PublicationsTable = ({ publications }: { publications: Publication[] }) => {
   const t = useTranslationFn();
   return (
     <BaseProvenanceTable
@@ -274,7 +274,7 @@ const SpatialCoverageSection = ({ spatialCoverage }: { spatialCoverage: NonNulla
 
 // ---- Extra properties ----
 
-const ExtraPropertiesTableV2 = ({ extra }: { extra: Dataset['extra_properties'] }) => {
+const ExtraPropertiesTable = ({ extra }: { extra: Dataset['extra_properties'] }) => {
   const t = useTranslationFn();
   if (!extra) return null;
   const rows = Object.entries(extra).map(([k, v]) => ({ key: k, value: String(v ?? '') }));
@@ -423,7 +423,7 @@ export const DatasetProvenanceContent = ({ dataset }: { dataset: Dataset }) => {
       {publications.length > 0 && (
         <>
           <SectionTitle title="Publications" />
-          <PublicationsTableV2 publications={publications} />
+          <PublicationsTable publications={publications} />
         </>
       )}
 
@@ -476,7 +476,7 @@ export const DatasetProvenanceContent = ({ dataset }: { dataset: Dataset }) => {
       {dataset.extra_properties && Object.keys(dataset.extra_properties).length > 0 && (
         <>
           <SectionTitle title="Extra Properties" />
-          <ExtraPropertiesTableV2 extra={dataset.extra_properties} />
+          <ExtraPropertiesTable extra={dataset.extra_properties} />
         </>
       )}
     </>

--- a/src/js/components/Scope/DatasetScopePicker.tsx
+++ b/src/js/components/Scope/DatasetScopePicker.tsx
@@ -25,7 +25,7 @@ const DatasetScopePicker = ({ parentProject }: DatasetScopePickerProps) => {
   const showClearDataset = useMemo(
     () =>
       // only show the clear dataset option if the selected dataset belongs to the parentProject
-      scopeObj.dataset && parentProject.datasets_v2.some((d) => d.identifier == scopeObj.dataset),
+      scopeObj.dataset && parentProject.datasets.some((d) => d.identifier == scopeObj.dataset),
     [scopeObj, parentProject]
   );
   const showSelectProject = !selectedScope.fixedProject && parentProject.identifier != scopeObj.project;
@@ -50,7 +50,7 @@ const DatasetScopePicker = ({ parentProject }: DatasetScopePickerProps) => {
         {showClearDataset && <a onClick={navigateToParentProject}>{t('Clear dataset selection')}</a>}
       </Space>
       <List
-        dataSource={parentProject.datasets_v2}
+        dataSource={parentProject.datasets}
         bordered
         renderItem={(d) => (
           <Dataset

--- a/src/js/constants/configConstants.ts
+++ b/src/js/constants/configConstants.ts
@@ -13,7 +13,6 @@ export const katsuDiscoveryUIHintsUrl = `${katsuBaseUrl}/api/discovery_ui_hints`
 
 // Katsu entity API (Django Rest Framework) base URLs
 export const projectsUrl = `${katsuBaseUrl}/api/projects`;
-export const datasetsUrl = `${katsuBaseUrl}/api/datasets`;
 export const individualUrl = `${katsuBaseUrl}/api/individuals`;
 export const individualBatchUrl = `${katsuBaseUrl}/api/batch/individuals`;
 export const phenopacketUrl = `${katsuBaseUrl}/api/phenopackets`;

--- a/src/js/features/metadata/hooks.ts
+++ b/src/js/features/metadata/hooks.ts
@@ -37,7 +37,7 @@ export const useSelectedDataset = (): Dataset | undefined => {
     },
   } = useMetadata();
   return useMemo(
-    () => (selectedProject ? selectedProject.datasets_v2.find((d) => d.identifier === selectedDatasetID) : undefined),
+    () => (selectedProject ? selectedProject.datasets.find((d) => d.identifier === selectedDatasetID) : undefined),
     [selectedProject, selectedDatasetID]
   );
 };
@@ -50,7 +50,7 @@ export const useSelectedScopeTitles = () => {
     () => ({
       projectTitle: selectedProject?.title,
       datasetTitle: scope.dataset
-        ? selectedProject?.datasets_v2.find((dataset) => dataset.identifier === scope.dataset)?.title
+        ? selectedProject?.datasets.find((dataset) => dataset.identifier === scope.dataset)?.title
         : null,
     }),
     [selectedProject, scope]

--- a/src/js/features/metadata/metadata.store.ts
+++ b/src/js/features/metadata/metadata.store.ts
@@ -101,9 +101,9 @@ const metadata = createSlice({
       const projects = payload?.results ?? [];
       state.projects = projects;
       state.projectsByID = Object.fromEntries(projects.map((p) => [p.identifier, p]));
-      state.datasetsByID = Object.fromEntries(projects.flatMap((p) => p.datasets_v2.map((d) => [d.identifier, d])));
+      state.datasetsByID = Object.fromEntries(projects.flatMap((p) => p.datasets.map((d) => [d.identifier, d])));
       state.datasetToProjectMap = Object.fromEntries(
-        projects.flatMap((p) => p.datasets_v2.map((d) => [d.identifier, p.identifier]))
+        projects.flatMap((p) => p.datasets.map((d) => [d.identifier, p.identifier]))
       );
       state.projectsStatus = RequestStatus.Fulfilled;
       state.projectsError = '';

--- a/src/js/types/metadata.ts
+++ b/src/js/types/metadata.ts
@@ -7,7 +7,7 @@ export interface Project {
   title: string;
   description: string;
   discovery: DiscoveryConfig | null;
-  datasets_v2: Dataset[];
+  datasets: Dataset[];
   created: string;
   updated: string;
   counts?: KatsuEntityCountsOrBooleans;

--- a/src/js/utils/router.ts
+++ b/src/js/utils/router.ts
@@ -52,10 +52,10 @@ export const validProjectDataset = (
     const defaultProj = projects[0];
     valid.scope.project = defaultProj.identifier;
     valid.fixedProject = true;
-    if (defaultProj.datasets_v2.length === 1) {
+    if (defaultProj.datasets.length === 1) {
       // TODO: only if the dataset-level permissions equal the project-level ones...
       // automatic dataset scoping if only 1
-      valid.scope.dataset = defaultProj.datasets_v2[0].identifier;
+      valid.scope.dataset = defaultProj.datasets[0].identifier;
       valid.fixedDataset = true;
       // early return to ignore redundant projectId and datasetId
       return valid;
@@ -66,7 +66,7 @@ export const validProjectDataset = (
 
   if (project && selectedProject) {
     valid.scope.project = project;
-    if (dataset && selectedProject.datasets_v2.find(({ identifier }) => identifier === dataset)) {
+    if (dataset && selectedProject.datasets.find(({ identifier }) => identifier === dataset)) {
       valid.scope.dataset = dataset;
     }
   }


### PR DESCRIPTION
## Summary

**Redmine ticket**: [2833](https://redmine.c3g-app.sd4h.ca/issues/2833)

- Removed unused `datasetsUrl` constant (`{katsu}/api/datasets` — never called)
- Renamed `datasets_v2` → `datasets` on the `Project` type and all usages across the frontend

**Requires https://github.com/bento-platform/katsu/pull/704**