### PR TITLE
fix: enforce min/max on all numeric range filter inputs

### DIFF
--- a/src/js/components/Search/NumberRangeFilterInput.tsx
+++ b/src/js/components/Search/NumberRangeFilterInput.tsx
@@ -116,6 +116,9 @@ const NumberRangeFilterInput = ({ definition, value, onChange }: Props) => {
           className="flex-1 w-full"
           controls={false}
           status={lowerBelowMin ? 'error' : undefined}
+          // Compact items default to z-index 2; the bracket button (later in DOM) paints on top at the same level.
+          // z-index 3 matches Ant Design's hover/focus elevation and keeps the error border fully visible.
+          style={lowerBelowMin ? { position: 'relative', zIndex: 3 } : undefined}
           value={lowerStr ? parseFloat(lowerStr) : null}
           onChange={onLowerNumberChange}
           placeholder={minimum !== null ? String(minimum) : 'min'}
@@ -125,6 +128,9 @@ const NumberRangeFilterInput = ({ definition, value, onChange }: Props) => {
           className="flex-1 w-full"
           controls={false}
           status={boundsInverted || upperAboveMax ? 'error' : undefined}
+          // Compact items default to z-index 2; the bracket button (later in DOM) paints on top at the same level.
+          // z-index 3 matches Ant Design's hover/focus elevation and keeps the error border fully visible.
+          style={boundsInverted || upperAboveMax ? { position: 'relative', zIndex: 3 } : undefined}
           value={upperStr ? parseFloat(upperStr) : null}
           onChange={onUpperNumberChange}
           placeholder={maximum !== null ? String(maximum) : 'max'}

--- a/src/js/components/Search/NumberRangeFilterInput.tsx
+++ b/src/js/components/Search/NumberRangeFilterInput.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Button, InputNumber, Space, Tooltip } from 'antd';
+import { Button, InputNumber, Space, Tooltip, Typography } from 'antd';
 
 import type { NumberField } from '@/types/discovery/fieldDefinition';
 import type { FilterValue } from '@/features/search/types';
@@ -45,14 +45,18 @@ const NumberRangeFilterInput = ({ definition, value, onChange }: Props) => {
 
   const emitValue = useCallback(
     (lStr: string, uStr: string, lo: boolean, uo: boolean) => {
-      const inverted = !!lStr && !!uStr && parseFloat(uStr) < parseFloat(lStr);
-      const result = inverted
-        ? null
-        : (buildRangeString(lStr, uStr, lo, uo) ?? buildComparisonString(lStr, uStr, lo, uo));
+      const lNum = lStr ? parseFloat(lStr) : null;
+      const uNum = uStr ? parseFloat(uStr) : null;
+      const inverted = lNum !== null && uNum !== null && uNum < lNum;
+      const outOfRange =
+        (enforcedMin !== undefined && lNum !== null && lNum < enforcedMin) ||
+        (enforcedMax !== undefined && uNum !== null && uNum > enforcedMax);
+      const result =
+        inverted || outOfRange ? null : (buildRangeString(lStr, uStr, lo, uo) ?? buildComparisonString(lStr, uStr, lo, uo));
       lastEmittedRef.current = result;
       onChange(result);
     },
-    [onChange]
+    [onChange, enforcedMin, enforcedMax]
   );
 
   // Debounced variant for number inputs — bracket toggles use emitValue directly (discrete actions).
@@ -101,35 +105,47 @@ const NumberRangeFilterInput = ({ definition, value, onChange }: Props) => {
   const upperAboveMax = enforcedMax !== undefined && upperNum !== null && upperNum > enforcedMax;
 
   return (
-    <Space.Compact className="w-full">
-      <Tooltip
-        title={`${t(lowerOpen ? 'search.range.lower_exclusive' : 'search.range.lower_inclusive')} — ${t('search.range.click_to_switch')}`}
-      >
-        <Button onClick={onLowerBracketToggle}>{lowerOpen ? '(' : '['}</Button>
-      </Tooltip>
-      <InputNumber
-        className="flex-1 w-full"
-        controls={false}
-        status={lowerBelowMin ? 'warning' : undefined}
-        value={lowerStr ? parseFloat(lowerStr) : null}
-        onChange={onLowerNumberChange}
-        placeholder={minimum !== null ? String(minimum) : 'min'}
-      />
-      <span className="range-separator">–</span>
-      <InputNumber
-        className="flex-1 w-full"
-        controls={false}
-        status={boundsInverted ? 'error' : upperAboveMax ? 'warning' : undefined}
-        value={upperStr ? parseFloat(upperStr) : null}
-        onChange={onUpperNumberChange}
-        placeholder={maximum !== null ? String(maximum) : 'max'}
-      />
-      <Tooltip
-        title={`${t(upperOpen ? 'search.range.upper_exclusive' : 'search.range.upper_inclusive')} — ${t('search.range.click_to_switch')}`}
-      >
-        <Button onClick={onUpperBracketToggle}>{upperOpen ? ')' : ']'}</Button>
-      </Tooltip>
-    </Space.Compact>
+    <div className="w-full">
+      <Space.Compact className="w-full">
+        <Tooltip
+          title={`${t(lowerOpen ? 'search.range.lower_exclusive' : 'search.range.lower_inclusive')} — ${t('search.range.click_to_switch')}`}
+        >
+          <Button onClick={onLowerBracketToggle}>{lowerOpen ? '(' : '['}</Button>
+        </Tooltip>
+        <InputNumber
+          className="flex-1 w-full"
+          controls={false}
+          status={lowerBelowMin ? 'warning' : undefined}
+          value={lowerStr ? parseFloat(lowerStr) : null}
+          onChange={onLowerNumberChange}
+          placeholder={minimum !== null ? String(minimum) : 'min'}
+        />
+        <span className="range-separator">–</span>
+        <InputNumber
+          className="flex-1 w-full"
+          controls={false}
+          status={boundsInverted ? 'error' : upperAboveMax ? 'warning' : undefined}
+          value={upperStr ? parseFloat(upperStr) : null}
+          onChange={onUpperNumberChange}
+          placeholder={maximum !== null ? String(maximum) : 'max'}
+        />
+        <Tooltip
+          title={`${t(upperOpen ? 'search.range.upper_exclusive' : 'search.range.upper_inclusive')} — ${t('search.range.click_to_switch')}`}
+        >
+          <Button onClick={onUpperBracketToggle}>{upperOpen ? ')' : ']'}</Button>
+        </Tooltip>
+      </Space.Compact>
+      {lowerBelowMin && (
+        <Typography.Text type="warning" className="text-xs">
+          {t('search.range.below_minimum', { min: enforcedMin })}
+        </Typography.Text>
+      )}
+      {upperAboveMax && (
+        <Typography.Text type="warning" className="text-xs">
+          {t('search.range.above_maximum', { max: enforcedMax })}
+        </Typography.Text>
+      )}
+    </div>
   );
 };
 

--- a/src/js/components/Search/NumberRangeFilterInput.tsx
+++ b/src/js/components/Search/NumberRangeFilterInput.tsx
@@ -110,7 +110,6 @@ const NumberRangeFilterInput = ({ definition, value, onChange }: Props) => {
       <InputNumber
         className="flex-1 w-full"
         controls={false}
-        min={enforcedMin}
         status={lowerBelowMin ? 'warning' : undefined}
         value={lowerStr ? parseFloat(lowerStr) : null}
         onChange={onLowerNumberChange}
@@ -120,7 +119,6 @@ const NumberRangeFilterInput = ({ definition, value, onChange }: Props) => {
       <InputNumber
         className="flex-1 w-full"
         controls={false}
-        max={enforcedMax}
         status={boundsInverted ? 'error' : upperAboveMax ? 'warning' : undefined}
         value={upperStr ? parseFloat(upperStr) : null}
         onChange={onUpperNumberChange}

--- a/src/js/components/Search/NumberRangeFilterInput.tsx
+++ b/src/js/components/Search/NumberRangeFilterInput.tsx
@@ -115,7 +115,7 @@ const NumberRangeFilterInput = ({ definition, value, onChange }: Props) => {
         <InputNumber
           className="flex-1 w-full"
           controls={false}
-          status={lowerBelowMin ? 'warning' : undefined}
+          status={lowerBelowMin ? 'error' : undefined}
           value={lowerStr ? parseFloat(lowerStr) : null}
           onChange={onLowerNumberChange}
           placeholder={minimum !== null ? String(minimum) : 'min'}
@@ -124,7 +124,7 @@ const NumberRangeFilterInput = ({ definition, value, onChange }: Props) => {
         <InputNumber
           className="flex-1 w-full"
           controls={false}
-          status={boundsInverted ? 'error' : upperAboveMax ? 'warning' : undefined}
+          status={boundsInverted || upperAboveMax ? 'error' : undefined}
           value={upperStr ? parseFloat(upperStr) : null}
           onChange={onUpperNumberChange}
           placeholder={maximum !== null ? String(maximum) : 'max'}
@@ -136,12 +136,12 @@ const NumberRangeFilterInput = ({ definition, value, onChange }: Props) => {
         </Tooltip>
       </Space.Compact>
       {lowerBelowMin && (
-        <Typography.Text type="warning" className="text-xs">
+        <Typography.Text type="danger" className="text-xs">
           {t('search.range.below_minimum', { min: enforcedMin })}
         </Typography.Text>
       )}
       {upperAboveMax && (
-        <Typography.Text type="warning" className="text-xs">
+        <Typography.Text type="danger" className="text-xs">
           {t('search.range.above_maximum', { max: enforcedMax })}
         </Typography.Text>
       )}

--- a/src/js/components/Search/NumberRangeFilterInput.tsx
+++ b/src/js/components/Search/NumberRangeFilterInput.tsx
@@ -136,14 +136,18 @@ const NumberRangeFilterInput = ({ definition, value, onChange }: Props) => {
         </Tooltip>
       </Space.Compact>
       {lowerBelowMin && (
-        <Typography.Text type="danger" className="text-xs">
-          {t('search.range.below_minimum', { min: enforcedMin })}
-        </Typography.Text>
+        <div>
+          <Typography.Text type="danger" className="text-xs">
+            {t('search.range.below_minimum', { min: enforcedMin })}
+          </Typography.Text>
+        </div>
       )}
       {upperAboveMax && (
-        <Typography.Text type="danger" className="text-xs">
-          {t('search.range.above_maximum', { max: enforcedMax })}
-        </Typography.Text>
+        <div>
+          <Typography.Text type="danger" className="text-xs">
+            {t('search.range.above_maximum', { max: enforcedMax })}
+          </Typography.Text>
+        </div>
       )}
     </div>
   );

--- a/src/js/components/Search/NumberRangeFilterInput.tsx
+++ b/src/js/components/Search/NumberRangeFilterInput.tsx
@@ -11,8 +11,8 @@ type Props = { definition: NumberField; value: FilterValue; onChange: (v: Filter
 const NumberRangeFilterInput = ({ definition, value, onChange }: Props) => {
   const t = useTranslationFn();
   const { minimum, maximum } = definition.config;
-  const enforcedMin =
-    'taper_left' in definition.config && minimum !== definition.config?.taper_left ? (minimum ?? undefined) : undefined;
+  const enforcedMin = minimum != null ? minimum : undefined;
+  const enforcedMax = maximum != null ? maximum : undefined;
   const rawValue = Array.isArray(value) ? (value[0] ?? null) : value;
 
   // Local state buffers what the user is typing. We can't derive from rawValue directly because
@@ -117,6 +117,7 @@ const NumberRangeFilterInput = ({ definition, value, onChange }: Props) => {
       <InputNumber
         className="flex-1 w-full"
         controls={false}
+        max={enforcedMax}
         status={boundsInverted ? 'error' : undefined}
         value={upperStr ? parseFloat(upperStr) : null}
         onChange={onUpperNumberChange}

--- a/src/js/components/Search/NumberRangeFilterInput.tsx
+++ b/src/js/components/Search/NumberRangeFilterInput.tsx
@@ -97,6 +97,8 @@ const NumberRangeFilterInput = ({ definition, value, onChange }: Props) => {
   const lowerNum = lowerStr ? parseFloat(lowerStr) : null;
   const upperNum = upperStr ? parseFloat(upperStr) : null;
   const boundsInverted = lowerNum !== null && upperNum !== null && upperNum < lowerNum;
+  const lowerBelowMin = enforcedMin !== undefined && lowerNum !== null && lowerNum < enforcedMin;
+  const upperAboveMax = enforcedMax !== undefined && upperNum !== null && upperNum > enforcedMax;
 
   return (
     <Space.Compact className="w-full">
@@ -109,6 +111,7 @@ const NumberRangeFilterInput = ({ definition, value, onChange }: Props) => {
         className="flex-1 w-full"
         controls={false}
         min={enforcedMin}
+        status={lowerBelowMin ? 'warning' : undefined}
         value={lowerStr ? parseFloat(lowerStr) : null}
         onChange={onLowerNumberChange}
         placeholder={minimum !== null ? String(minimum) : 'min'}
@@ -118,7 +121,7 @@ const NumberRangeFilterInput = ({ definition, value, onChange }: Props) => {
         className="flex-1 w-full"
         controls={false}
         max={enforcedMax}
-        status={boundsInverted ? 'error' : undefined}
+        status={boundsInverted ? 'error' : upperAboveMax ? 'warning' : undefined}
         value={upperStr ? parseFloat(upperStr) : null}
         onChange={onUpperNumberChange}
         placeholder={maximum !== null ? String(maximum) : 'max'}

--- a/src/js/components/Search/NumberRangeFilterInput.tsx
+++ b/src/js/components/Search/NumberRangeFilterInput.tsx
@@ -52,7 +52,9 @@ const NumberRangeFilterInput = ({ definition, value, onChange }: Props) => {
         (enforcedMin !== undefined && lNum !== null && lNum < enforcedMin) ||
         (enforcedMax !== undefined && uNum !== null && uNum > enforcedMax);
       const result =
-        inverted || outOfRange ? null : (buildRangeString(lStr, uStr, lo, uo) ?? buildComparisonString(lStr, uStr, lo, uo));
+        inverted || outOfRange
+          ? null
+          : (buildRangeString(lStr, uStr, lo, uo) ?? buildComparisonString(lStr, uStr, lo, uo));
       lastEmittedRef.current = result;
       onChange(result);
     },

--- a/src/public/locales/en/default_translation_en.json
+++ b/src/public/locales/en/default_translation_en.json
@@ -77,7 +77,9 @@
       "lower_exclusive": "Lower bound exclusive",
       "upper_inclusive": "Upper bound inclusive",
       "upper_exclusive": "Upper bound exclusive",
-      "click_to_switch": "Click to switch"
+      "click_to_switch": "Click to switch",
+      "below_minimum": "Value must be ≥ {{min}}",
+      "above_maximum": "Value must be ≤ {{max}}"
     }
   },
   "OR": "OR",

--- a/src/public/locales/en/default_translation_en.json
+++ b/src/public/locales/en/default_translation_en.json
@@ -78,8 +78,8 @@
       "upper_inclusive": "Upper bound inclusive",
       "upper_exclusive": "Upper bound exclusive",
       "click_to_switch": "Click to switch",
-      "below_minimum": "Value must be ≥ {{min}}",
-      "above_maximum": "Value must be ≤ {{max}}"
+      "below_minimum": "Lower value must be ≥ {{min}}",
+      "above_maximum": "Upper value must be ≤ {{max}}"
     }
   },
   "OR": "OR",

--- a/src/public/locales/fr/default_translation_fr.json
+++ b/src/public/locales/fr/default_translation_fr.json
@@ -79,7 +79,9 @@
       "lower_exclusive": "Borne inférieure exclue",
       "upper_inclusive": "Borne supérieure incluse",
       "upper_exclusive": "Borne supérieure exclue",
-      "click_to_switch": "Cliquer pour changer"
+      "click_to_switch": "Cliquer pour changer",
+      "below_minimum": "La valeur doit être ≥ {{min}}",
+      "above_maximum": "La valeur doit être ≤ {{max}}"
     }
   },
   "OR": "OU",

--- a/src/public/locales/fr/default_translation_fr.json
+++ b/src/public/locales/fr/default_translation_fr.json
@@ -80,8 +80,8 @@
       "upper_inclusive": "Borne supérieure incluse",
       "upper_exclusive": "Borne supérieure exclue",
       "click_to_switch": "Cliquer pour changer",
-      "below_minimum": "La valeur doit être ≥ {{min}}",
-      "above_maximum": "La valeur doit être ≤ {{max}}"
+      "below_minimum": "La valeur inférieure doit être ≥ {{min}}",
+      "above_maximum": "La valeur supérieure doit être ≤ {{max}}"
     }
   },
   "OR": "OU",


### PR DESCRIPTION
## Summary

- Fixes [#2817](https://redmine.c3g-app.sd4h.ca/issues/2817)
- `ManualBinsNumberFieldConfig` fields never enforced `min` on the lower input, the previous check gated on `taper_left` which only exists on `AutoBinsNumberFieldConfig` (age fields)
- No numeric field type enforced `max` on the upper input at all
- Now both `min` and `max` are applied to their respective inputs whenever the field config defines `minimum`/`maximum`