### PR TITLE
fix(catalogue): style fixes for footer, insights, and scope header

### DIFF
--- a/src/js/components/Overview/OverviewDatasets.tsx
+++ b/src/js/components/Overview/OverviewDatasets.tsx
@@ -22,6 +22,7 @@ const OverviewDatasets = ({
               parentProjectID={parentProjectID}
               dataset={d}
               format="card"
+              fromProject
               filteredCounts={
                 countsByDataset ? (countsByDataset[d.identifier] ?? EMPTY_KATSU_ENTITY_COUNTS) : d.counts_by_entity
               }

--- a/src/js/components/Provenance/Catalogue/CatalogueInsights.tsx
+++ b/src/js/components/Provenance/Catalogue/CatalogueInsights.tsx
@@ -53,7 +53,7 @@ const CatalogueInsights = ({ filteredDatasets }: CatalogueInsightsProps) => {
     <div className="catalogue-insights">
       <Flex justify="space-between" align="center" className="mb-3">
         <Flex align="center" gap={6}>
-          <BarChartOutlined className="text-cat-primary" />
+          <BarChartOutlined className="text-secondary" />
           <Text className="catalogue-insights__header-title">{t('catalogue.insights.title')}</Text>
         </Flex>
         <Text className="catalogue-insights__hint">{t('catalogue.insights.hint')}</Text>

--- a/src/js/components/Provenance/Catalogue/CatalogueRail.tsx
+++ b/src/js/components/Provenance/Catalogue/CatalogueRail.tsx
@@ -3,6 +3,7 @@ import { useAppDispatch } from '@/hooks';
 import { useCatalogueState } from '@/features/catalogue/hooks';
 import { toggleFacetValue, toggleFacetCollapse, type FacetId } from '@/features/catalogue/catalogue.store';
 import { useTranslationFn } from '@/hooks';
+import { statusTranslationKey } from '@/features/catalogue/hooks';
 import { CaretDownOutlined, CaretRightOutlined } from '@ant-design/icons';
 import FilterChip from '@/components/Util/FilterChip';
 
@@ -48,7 +49,7 @@ const FacetSection = ({ facet, options, collapsed, onToggleCollapse, onToggleVal
           {options.map(({ value, count, selected }) => (
             <FilterChip
               key={value}
-              label={value}
+              label={facet.id === 'statuses' ? t(statusTranslationKey(value)) : value}
               count={count}
               selected={selected}
               onClick={() => onToggleValue(value)}

--- a/src/js/components/Provenance/Catalogue/Charts/DonutChart.tsx
+++ b/src/js/components/Provenance/Catalogue/Charts/DonutChart.tsx
@@ -10,6 +10,23 @@ const SIZE = 116,
   R = 46,
   CIRC = 2 * Math.PI * R;
 
+const wrapCenterLabel = (label: string, maxLineLen = 10): string[] => {
+  const words = label.split(' ');
+  const lines: string[] = [];
+  let current = '';
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word;
+    if (candidate.length > maxLineLen && current) {
+      lines.push(current);
+      current = word;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current) lines.push(current);
+  return lines;
+};
+
 interface DonutChartProps {
   title: string;
   data: { name: string; value: number }[];
@@ -47,6 +64,7 @@ const DonutChart = ({
   );
 
   const c = SIZE / 2;
+  const centerLabelLines = wrapCenterLabel(centerLabel);
 
   return (
     <Card size="small" className="chart-card">
@@ -74,12 +92,14 @@ const DonutChart = ({
               </title>
             </circle>
           ))}
-          <text x={c} y={c - 3} className="donut-num">
+          <text x={c} y={c - 6} className="donut-num">
             {fmt(total)}
           </text>
-          <text x={c} y={c + 13} className="donut-lbl">
-            {centerLabel}
-          </text>
+          {centerLabelLines.map((line, i) => (
+            <text key={i} x={c} y={c + 9 + i * 9} className="donut-lbl">
+              {line}
+            </text>
+          ))}
         </svg>
         <div className="chart-legend">
           {data.map((entry) => {

--- a/src/js/components/Provenance/Catalogue/Charts/DonutChart.tsx
+++ b/src/js/components/Provenance/Catalogue/Charts/DonutChart.tsx
@@ -10,22 +10,8 @@ const SIZE = 116,
   R = 46,
   CIRC = 2 * Math.PI * R;
 
-const wrapCenterLabel = (label: string, maxLineLen = 10): string[] => {
-  const words = label.split(' ');
-  const lines: string[] = [];
-  let current = '';
-  for (const word of words) {
-    const candidate = current ? `${current} ${word}` : word;
-    if (candidate.length > maxLineLen && current) {
-      lines.push(current);
-      current = word;
-    } else {
-      current = candidate;
-    }
-  }
-  if (current) lines.push(current);
-  return lines;
-};
+const LABEL_WIDTH = 74;
+const LABEL_HEIGHT = 30;
 
 interface DonutChartProps {
   title: string;
@@ -64,7 +50,6 @@ const DonutChart = ({
   );
 
   const c = SIZE / 2;
-  const centerLabelLines = wrapCenterLabel(centerLabel);
 
   return (
     <Card size="small" className="chart-card">
@@ -95,11 +80,9 @@ const DonutChart = ({
           <text x={c} y={c - 6} className="donut-num">
             {fmt(total)}
           </text>
-          {centerLabelLines.map((line, i) => (
-            <text key={i} x={c} y={c + 9 + i * 9} className="donut-lbl">
-              {line}
-            </text>
-          ))}
+          <foreignObject x={c - LABEL_WIDTH / 2} y={c + 2} width={LABEL_WIDTH} height={LABEL_HEIGHT}>
+            <div className="donut-lbl">{centerLabel}</div>
+          </foreignObject>
         </svg>
         <div className="chart-legend">
           {data.map((entry) => {

--- a/src/js/components/Provenance/Catalogue/Charts/DonutChart.tsx
+++ b/src/js/components/Provenance/Catalogue/Charts/DonutChart.tsx
@@ -1,6 +1,7 @@
 import { Card, Typography } from 'antd';
 import { useFormatNumber, useTranslationFn } from '@/hooks';
 import type { FacetId } from '@/features/catalogue/catalogue.store';
+import { statusTranslationKey } from '@/features/catalogue/hooks';
 import { COLOR_CHART_FALLBACK, COLOR_DONUT_TRACK } from '../constants';
 
 const { Text } = Typography;
@@ -94,7 +95,9 @@ const DonutChart = ({
                 onClick={() => onSegmentClick(facetId, entry.name)}
               >
                 <span className="dot" style={{ background: colors[entry.name] ?? DEFAULT_COLOR }} />
-                <span className="legend-lbl">{t(entry.name)}</span>
+                <span className="legend-lbl">
+                  {facetId === 'statuses' ? t(statusTranslationKey(entry.name)) : t(entry.name)}
+                </span>
                 <span className="legend-val">{fmt(entry.value)}</span>
               </div>
             );

--- a/src/js/components/Provenance/Dataset.tsx
+++ b/src/js/components/Provenance/Dataset.tsx
@@ -124,7 +124,7 @@ const Dataset = ({
             ellipsis={{
               rows: 3,
               expandable: true,
-              symbol: <span className="catalogue-card__expand-symbol">{t('more', { count: 1 })}</span>,
+              symbol: <span className="catalogue-card__expand-symbol">{t('catalogue.datasets.expand')}</span>,
             }}
             className="catalogue-card__description"
           >

--- a/src/js/components/Provenance/Dataset.tsx
+++ b/src/js/components/Provenance/Dataset.tsx
@@ -31,6 +31,7 @@ const Dataset = ({
   project,
   selected,
   filteredCounts,
+  fromProject,
 }: {
   parentProjectID: string;
   dataset: Dataset;
@@ -38,6 +39,9 @@ const Dataset = ({
   project?: Project;
   selected?: boolean;
   filteredCounts?: KatsuEntityCountsOrBooleans;
+  // Whether this dataset is being linked to from within its parent project's own page - used to inform the
+  // dataset scope's back button (in PCGL mode, it otherwise defaults to going back to the catalogue).
+  fromProject?: boolean;
 }) => {
   const language = useLanguage();
   const navigateToScope = useNavigateToScope();
@@ -53,9 +57,19 @@ const Dataset = ({
     () => ({ project: parentProjectID, dataset: identifier }),
     [parentProjectID, identifier]
   );
+  const navigateOptions = useMemo(
+    () => (fromProject ? { state: { fromProjectScope: true } } : undefined),
+    [fromProject]
+  );
 
-  const onNavigateCurrent = useCallback(() => navigateToScope(scope, page), [navigateToScope, scope, page]);
-  const onNavigateOverview = useCallback(() => navigateToScope(scope, BentoRoute.Overview), [navigateToScope, scope]);
+  const onNavigateCurrent = useCallback(
+    () => navigateToScope(scope, page, false, navigateOptions),
+    [navigateToScope, scope, page, navigateOptions]
+  );
+  const onNavigateOverview = useCallback(
+    () => navigateToScope(scope, BentoRoute.Overview, false, navigateOptions),
+    [navigateToScope, scope, navigateOptions]
+  );
 
   const openProvenanceModal = useCallback(() => setProvenanceModalOpen(true), []);
   const closeProvenanceModal = useCallback(() => setProvenanceModalOpen(false), []);

--- a/src/js/components/Provenance/Dataset.tsx
+++ b/src/js/components/Provenance/Dataset.tsx
@@ -110,7 +110,7 @@ const Dataset = ({
             ellipsis={{
               rows: 3,
               expandable: true,
-              symbol: <span className="catalogue-card__expand-symbol">more</span>,
+              symbol: <span className="catalogue-card__expand-symbol">{t('more', { count: 1 })}</span>,
             }}
             className="catalogue-card__description"
           >

--- a/src/js/components/Scope/DatasetScopePicker.tsx
+++ b/src/js/components/Scope/DatasetScopePicker.tsx
@@ -58,6 +58,7 @@ const DatasetScopePicker = ({ parentProject }: DatasetScopePickerProps) => {
             dataset={d}
             format="list-item"
             selected={scopeObj.dataset === d.identifier}
+            fromProject
           />
         )}
       />

--- a/src/js/components/Scope/ScopeHeader.tsx
+++ b/src/js/components/Scope/ScopeHeader.tsx
@@ -36,7 +36,8 @@ const useBackButtonInfo = () => {
     } else {
       if (scope.dataset) {
         if (fixedDataset) return NO_BACK_BUTTON;
-        return PCGL_MODE
+        const cameFromProject = (location.state as { fromProjectScope?: boolean } | null)?.fromProjectScope;
+        return PCGL_MODE && !cameFromProject
           ? ['Back to catalogue', navigateToRoot]
           : ['Back to project', () => navigateToScope({ project: scope.project }, BentoRoute.Overview)];
       } else if (scope.project) {
@@ -47,6 +48,7 @@ const useBackButtonInfo = () => {
     }
   }, [
     currentPage,
+    location.state,
     navigateToRoot,
     navigateToScope,
     navigateToSameScopeUrl,

--- a/src/js/components/Scope/ScopeHeader.tsx
+++ b/src/js/components/Scope/ScopeHeader.tsx
@@ -12,6 +12,7 @@ import { useNavigateToRoot, useNavigateToSameScopeUrl, useNavigateToScope } from
 import { BentoRoute } from '@/types/routes';
 import { getCurrentPage } from '@/utils/router';
 import { buildQueryParamsUrl } from '@/features/search/utils';
+import { PCGL_MODE } from '@/config';
 
 const NO_BACK_BUTTON = [undefined, undefined] as const;
 
@@ -34,8 +35,9 @@ const useBackButtonInfo = () => {
       ];
     } else {
       if (scope.dataset) {
-        return fixedDataset
-          ? NO_BACK_BUTTON
+        if (fixedDataset) return NO_BACK_BUTTON;
+        return PCGL_MODE
+          ? ['Back to catalogue', navigateToRoot]
           : ['Back to project', () => navigateToScope({ project: scope.project }, BentoRoute.Overview)];
       } else if (scope.project) {
         return fixedProject ? NO_BACK_BUTTON : ['Back to catalogue', navigateToRoot];

--- a/src/js/components/Search/DateRangeFilterInput.tsx
+++ b/src/js/components/Search/DateRangeFilterInput.tsx
@@ -4,7 +4,13 @@ import dayjs from 'dayjs';
 import type { Dayjs } from 'dayjs';
 
 import type { FilterValue } from '@/features/search/types';
-import { parseBrackets, buildRangeString, buildComparisonString, DATE_FORMAT, type RangeState } from '@/utils/rangeFilterUtils';
+import {
+  parseBrackets,
+  buildRangeString,
+  buildComparisonString,
+  DATE_FORMAT,
+  type RangeState,
+} from '@/utils/rangeFilterUtils';
 
 type Props = { value: FilterValue; onChange: (v: FilterValue) => void };
 

--- a/src/js/components/Search/DateRangeFilterInput.tsx
+++ b/src/js/components/Search/DateRangeFilterInput.tsx
@@ -4,7 +4,7 @@ import dayjs from 'dayjs';
 import type { Dayjs } from 'dayjs';
 
 import type { FilterValue } from '@/features/search/types';
-import { parseBrackets, buildRangeString, DATE_FORMAT, type RangeState } from '@/utils/rangeFilterUtils';
+import { parseBrackets, buildRangeString, buildComparisonString, DATE_FORMAT, type RangeState } from '@/utils/rangeFilterUtils';
 
 type Props = { value: FilterValue; onChange: (v: FilterValue) => void };
 
@@ -40,7 +40,9 @@ const DateRangeFilterInput = ({ value, onChange }: Props) => {
       const lower = lStr ? dayjs(lStr, DATE_FORMAT) : null;
       const upper = uStr ? dayjs(uStr, DATE_FORMAT) : null;
       const inverted = !!(lower?.isValid() && upper?.isValid() && upper.isBefore(lower, 'day'));
-      const result = inverted ? null : buildRangeString(lStr, uStr, false, false);
+      const result = inverted
+        ? null
+        : (buildRangeString(lStr, uStr, false, false) ?? buildComparisonString(lStr, uStr, false, false));
       lastEmittedRef.current = result;
       onChange(result);
     },

--- a/src/js/components/Search/NumberRangeFilterInput.tsx
+++ b/src/js/components/Search/NumberRangeFilterInput.tsx
@@ -14,7 +14,9 @@ const NumberRangeFilterInput = ({ definition, value, onChange }: Props) => {
   const enforcedMin =
     'taper_left' in definition.config && minimum === definition.config.taper_left ? undefined : (minimum ?? undefined);
   const enforcedMax =
-    'taper_right' in definition.config && maximum === definition.config.taper_right ? undefined : (maximum ?? undefined);
+    'taper_right' in definition.config && maximum === definition.config.taper_right
+      ? undefined
+      : (maximum ?? undefined);
   const rawValue = Array.isArray(value) ? (value[0] ?? null) : value;
 
   // Local state buffers what the user is typing. We can't derive from rawValue directly because

--- a/src/js/components/Search/NumberRangeFilterInput.tsx
+++ b/src/js/components/Search/NumberRangeFilterInput.tsx
@@ -12,7 +12,9 @@ const NumberRangeFilterInput = ({ definition, value, onChange }: Props) => {
   const t = useTranslationFn();
   const { minimum, maximum } = definition.config;
   const enforcedMin =
-    'taper_left' in definition.config && minimum !== definition.config?.taper_left ? (minimum ?? undefined) : undefined;
+    'taper_left' in definition.config && minimum === definition.config.taper_left ? undefined : (minimum ?? undefined);
+  const enforcedMax =
+    'taper_right' in definition.config && maximum === definition.config.taper_right ? undefined : (maximum ?? undefined);
   const rawValue = Array.isArray(value) ? (value[0] ?? null) : value;
 
   // Local state buffers what the user is typing. We can't derive from rawValue directly because
@@ -118,6 +120,7 @@ const NumberRangeFilterInput = ({ definition, value, onChange }: Props) => {
         className="flex-1 w-full"
         controls={false}
         status={boundsInverted ? 'error' : undefined}
+        max={enforcedMax}
         value={upperStr ? parseFloat(upperStr) : null}
         onChange={onUpperNumberChange}
         placeholder={maximum !== null ? String(maximum) : 'max'}

--- a/src/js/components/Util/StatusBadge.tsx
+++ b/src/js/components/Util/StatusBadge.tsx
@@ -1,15 +1,11 @@
-import { normaliseStatus } from '@/features/catalogue/hooks';
+import { normaliseStatus, statusTranslationKey } from '@/features/catalogue/hooks';
 import { useTranslationFn } from '@/hooks';
 
 const StatusBadge = ({ status }: { status?: string | null }) => {
   const t = useTranslationFn();
   const norm = normaliseStatus(status);
   if (!norm) return null;
-  return (
-    <span className={`status-badge status-badge--${norm.toLowerCase()}`}>
-      {t(`catalogue.status.${norm.toLowerCase()}`)}
-    </span>
-  );
+  return <span className={`status-badge status-badge--${norm.toLowerCase()}`}>{t(statusTranslationKey(norm))}</span>;
 };
 
 export default StatusBadge;

--- a/src/js/features/catalogue/hooks.ts
+++ b/src/js/features/catalogue/hooks.ts
@@ -14,6 +14,9 @@ export function normaliseStatus(raw: string | undefined | null): string {
   return 'Unassigned';
 }
 
+/** Builds the i18n key for a normalised status value, e.g., "Unassigned" -> "catalogue.status.unassigned". */
+export const statusTranslationKey = (status: string): string => `catalogue.status.${status.toLowerCase()}`;
+
 /** Ordered colour palette used to assign a stable colour per project name. */
 export const PALETTE = ['#1677FF', '#13C2C2', '#722ED1', '#FA8C16', '#52C41A'];
 

--- a/src/js/hooks/useSearchRouterAndHandler.ts
+++ b/src/js/hooks/useSearchRouterAndHandler.ts
@@ -104,9 +104,12 @@ export const useSearchRouterAndHandler = () => {
         const isComparison = /^([<>]|[≥≤])\s*-?\d+(\.\d+)?$/.test(value);
         return isRange || isComparison ? [field, true, value] : [field, false];
       }
-      // Date fields accept a range string, or a bin label (e.g. "Jan 2026" from a chart click) converted to a range.
+      // Date fields accept a range string, a single-sided comparison, or a bin label
+      // (e.g. "Jan 2026" from a chart click) converted to a range.
       if (queryDataPerm && field.definition.datatype === 'date') {
-        if (/^([[(][^,]+,[^,]+[\])])$/.test(value)) return [field, true, value];
+        const isRange = /^([[(][^,]+,[^,]+[\])])$/.test(value);
+        const isComparison = /^([<>]|[≥≤])\s*\d{4}-\d{2}-\d{2}$/.test(value);
+        if (isRange || isComparison) return [field, true, value];
         const rangeStr = parseDateBinAsRange(value);
         return rangeStr ? [field, true, rangeStr] : [field, false];
       }

--- a/src/js/hooks/useTitleBreadcrumbItems.tsx
+++ b/src/js/hooks/useTitleBreadcrumbItems.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import { HomeOutlined } from '@ant-design/icons';
 import type { BreadcrumbItemType } from 'antd/es/breadcrumb/Breadcrumb';
 
@@ -18,6 +19,8 @@ export const useTitleBreadcrumbItems = (): BreadcrumbItemType[] => {
 
   const { scope, fixedProject, fixedDataset } = useSelectedScope();
   const { projectTitle, datasetTitle } = useSelectedScopeTitles();
+  const location = useLocation();
+  const cameFromProject = (location.state as { fromProjectScope?: boolean } | null)?.fromProjectScope;
 
   const getRouteTitleAndIcon = useGetRouteTitleAndIcon();
 
@@ -30,7 +33,7 @@ export const useTitleBreadcrumbItems = (): BreadcrumbItemType[] => {
 
     const items: BreadcrumbItemType[] = [];
 
-    if (scope.project && !fixedProject && !(PCGL_MODE && scope.dataset)) {
+    if (scope.project && !fixedProject && !(PCGL_MODE && scope.dataset && !cameFromProject)) {
       // If we have more than one project (or we're in catalogue mode), fixedProject will be false, meaning we should
       // show project context in the navigation:
       items.push({
@@ -71,6 +74,7 @@ export const useTitleBreadcrumbItems = (): BreadcrumbItemType[] => {
     t,
     projectTitle,
     datasetTitle,
+    cameFromProject,
     scope,
     fixedProject,
     fixedDataset,

--- a/src/js/hooks/useTitleBreadcrumbItems.tsx
+++ b/src/js/hooks/useTitleBreadcrumbItems.tsx
@@ -9,6 +9,7 @@ import { useSmallScreen } from '@/hooks/useResponsiveContext';
 import { useGetRouteTitleAndIcon } from '@/hooks/navigation';
 import { useExtraBreadcrumb } from '@/features/ui/hooks';
 import { getCurrentPage } from '@/utils/router';
+import { PCGL_MODE } from '@/config';
 
 export const useTitleBreadcrumbItems = (): BreadcrumbItemType[] => {
   const t = useTranslationFn();
@@ -29,7 +30,7 @@ export const useTitleBreadcrumbItems = (): BreadcrumbItemType[] => {
 
     const items: BreadcrumbItemType[] = [];
 
-    if (scope.project && !fixedProject) {
+    if (scope.project && !fixedProject && !(PCGL_MODE && scope.dataset)) {
       // If we have more than one project (or we're in catalogue mode), fixedProject will be false, meaning we should
       // show project context in the navigation:
       items.push({

--- a/src/public/locales/en/default_translation_en.json
+++ b/src/public/locales/en/default_translation_en.json
@@ -571,7 +571,8 @@
     },
     "datasets": {
       "empty": "No datasets match your filters",
-      "reset_filters": "Clear all filters"
+      "reset_filters": "Clear all filters",
+      "expand": "more"
     },
     "status": {
       "ongoing": "Ongoing",

--- a/src/public/locales/fr/default_translation_fr.json
+++ b/src/public/locales/fr/default_translation_fr.json
@@ -204,7 +204,8 @@
     "datasets": {
       "heading": "Jeux de données",
       "no_results": "Aucun jeu de données ne correspond à vos filtres",
-      "clear_filters": "Effacer tous les filtres"
+      "clear_filters": "Effacer tous les filtres",
+      "expand": "plus"
     },
     "status": {
       "ongoing": "En cours",

--- a/src/styles.css
+++ b/src/styles.css
@@ -123,11 +123,11 @@ body {
 .pt-5 { padding-top: 20px; }
 .z-0 { z-index: 0; }
 .self-start { align-self: flex-start; }
-.text-cat-primary { color: var(--ant-color-primary, #054A74); }
-.text-secondary { color: var(--text-secondary); }
 
 /* custom, tailwind-esque */
 .max-w-half-cmw { max-width: calc(var(--content-max-width) / 2); }
+.text-cat-primary { color: var(--ant-color-primary, #054A74); }
+.text-secondary { color: var(--text-secondary); }
 
 .shadow {
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
@@ -570,7 +570,14 @@ body {
 .donut-wrap { display: flex; align-items: center; gap: 12px; }
 .donut { flex: none; }
 .donut-num { font-size: 18px; font-weight: 700; fill: rgba(0,0,0,0.88); text-anchor: middle; }
-.donut-lbl { font-size: 7px; fill: var(--text-muted); text-anchor: middle; text-transform: uppercase; letter-spacing: 0.04em; }
+.donut-lbl {
+  font-size: 8px;
+  color: var(--text-muted);
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  line-height: 1.2;
+}
 .dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
 .provenance-tag {
   font-size: 11px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -259,6 +259,7 @@ body {
   top: 0;
   left: 0;
   right: 0;
+  padding-right: var(--content-padding-h);
   background-color: rgba(250, 250, 250, 0.80);
   backdrop-filter: blur(10px);
   border-bottom: 1px solid rgb(235, 235, 235);
@@ -449,7 +450,7 @@ body {
 }
 
 #pcgl-footer {
-  --pcgl-footer-bg: color-mix(in srgb, var(--ant-color-primary, #054A74) 80%, black);
+  --pcgl-footer-bg: color-mix(in srgb, var(--ant-color-primary, #054A74) 60%, black);
   background-color: var(--pcgl-footer-bg);
   /* Hacky box-shadow protection against really short content revealing page background below: */
   box-shadow: 0 200px 0 var(--pcgl-footer-bg), 0 400px 0 var(--pcgl-footer-bg), 0 600px 0 var(--pcgl-footer-bg);

--- a/src/styles.css
+++ b/src/styles.css
@@ -259,9 +259,6 @@ body {
   top: 0;
   left: 0;
   right: 0;
-  padding-right: var(--content-padding-h);
-  padding-top: 8px;
-  padding-bottom: 8px;
   background-color: rgba(250, 250, 250, 0.80);
   backdrop-filter: blur(10px);
   border-bottom: 1px solid rgb(235, 235, 235);

--- a/src/styles.css
+++ b/src/styles.css
@@ -124,6 +124,7 @@ body {
 .z-0 { z-index: 0; }
 .self-start { align-self: flex-start; }
 .text-cat-primary { color: var(--ant-color-primary, #054A74); }
+.text-secondary { color: var(--text-secondary); }
 
 /* custom, tailwind-esque */
 .max-w-half-cmw { max-width: calc(var(--content-max-width) / 2); }
@@ -614,7 +615,7 @@ body {
   border-radius: 12px;
   padding: 14px 16px;
 }
-.catalogue-insights__header-title { color: var(--ant-color-primary, #054A74); font-weight: 600; font-size: 14px; }
+.catalogue-insights__header-title { color: var(--text-secondary); font-weight: 600; font-size: 14px; }
 .catalogue-insights__hint { font-size: 12px; color: var(--text-muted); }
 /* END catalogue insights */
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -570,7 +570,7 @@ body {
 .donut-wrap { display: flex; align-items: center; gap: 12px; }
 .donut { flex: none; }
 .donut-num { font-size: 18px; font-weight: 700; fill: rgba(0,0,0,0.88); text-anchor: middle; }
-.donut-lbl { font-size: 8px; fill: var(--text-muted); text-anchor: middle; text-transform: uppercase; letter-spacing: 0.05em; }
+.donut-lbl { font-size: 7px; fill: var(--text-muted); text-anchor: middle; text-transform: uppercase; letter-spacing: 0.04em; }
 .dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
 .provenance-tag {
   font-size: 11px;
@@ -600,7 +600,7 @@ body {
 /* BEGIN catalogue toolbar */
 .catalogue-search-input { flex-grow: 1; min-width: 200px; border-radius: 6px; }
 .catalogue-sort-select { width: 180px; }
-.catalogue-count-highlight { color: var(--ant-color-primary, #054A74); font-weight: 600; }
+.catalogue-count-highlight { color: rgba(0, 0, 0, 0.88); font-weight: 600; }
 .catalogue-filter-tag { border-radius: 13px !important; margin: 0 !important; }
 .catalogue-filter-tag__facet-label { color: var(--text-muted); font-size: 11px; margin-right: 3px; }
 .catalogue-clear-tag { border-radius: 13px !important; margin: 0 !important; cursor: pointer; border-style: dashed; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -451,10 +451,11 @@ body {
 }
 
 #pcgl-footer {
-  background-color: var(--ant-color-primary, #054A74);
+  --pcgl-footer-bg: color-mix(in srgb, var(--ant-color-primary, #054A74) 80%, black);
+  background-color: var(--pcgl-footer-bg);
   /* Hacky box-shadow protection against really short content revealing page background below: */
-  box-shadow: 0 200px 0 var(--ant-color-primary, #054A74), 0 400px 0 var(--ant-color-primary, #054A74), 0 600px 0 var(--ant-color-primary, #054A74);
-  border-top: 1px solid #02253B;  /* HSL of above darkened by 6pp */
+  box-shadow: 0 200px 0 var(--pcgl-footer-bg), 0 400px 0 var(--pcgl-footer-bg), 0 600px 0 var(--pcgl-footer-bg);
+  border-top: 1px solid color-mix(in srgb, var(--ant-color-primary, #054A74) 60%, black);
   font-size: 13px;
 }
 #pcgl-footer img {


### PR DESCRIPTION
## Summary
- Darken PCGL footer background via `color-mix()` against `--ant-color-primary` instead of a hardcoded hex
- Use `text-secondary` for the catalogue insights header icon and title
- Remove padding from the scope header