### PR TITLE
Consolidate faceted search UI (catalogue + search sidebar)

### DIFF
--- a/src/js/components/Overview/OverviewChartDashboard.tsx
+++ b/src/js/components/Overview/OverviewChartDashboard.tsx
@@ -98,7 +98,7 @@ const OverviewChartDashboard = () => {
           ) : null}
         </div>
 
-        <ActiveFilterTags pills={pills} onClearAll={clearAll} />
+        <ActiveFilterTags pills={pills} onClearAll={clearAll} tagClassName="overview-filter-tag" />
 
         {/*
             If we're in a scope with no data at all, don't bother rendering the

--- a/src/js/components/Overview/OverviewChartDashboard.tsx
+++ b/src/js/components/Overview/OverviewChartDashboard.tsx
@@ -21,8 +21,9 @@ import DatasetProvenance from '@/components/Provenance/DatasetProvenance';
 import { useTranslationFn } from '@/hooks';
 import { useSearchRouterAndHandler } from '@/hooks/useSearchRouterAndHandler';
 import { useSelectedDataset, useSelectedProject, useSelectedScope, useScopeHasData } from '@/features/metadata/hooks';
-import { useSearchQuery, useSearchableFields } from '@/features/search/hooks';
+import { useActiveFilterPills, useSearchQuery, useSearchableFields } from '@/features/search/hooks';
 import { useIsInCatalogueMode } from '@/hooks/navigation';
+import ActiveFilterTags from '@/components/Util/ActiveFilterTags';
 
 const saveScopeOverviewToLS = (scope: DiscoveryScope, sections: Sections) => {
   saveValue(generateLSChartDataKey(scope), convertSequenceAndDisplayData(sections));
@@ -48,6 +49,7 @@ const OverviewChartDashboard = () => {
   const searchableFields = useSearchableFields();
 
   const scopeHasData = useScopeHasData();
+  const { pills, clearAll } = useActiveFilterPills();
 
   // If we have no entities with data confirmed, don't bother showing charts (or last ingested details)
   const displayedSections = scopeHasData
@@ -95,6 +97,8 @@ const OverviewChartDashboard = () => {
             <DatasetProvenance dataset={selectedDataset} showTitle={false} />
           ) : null}
         </div>
+
+        <ActiveFilterTags pills={pills} onClearAll={clearAll} />
 
         {/*
             If we're in a scope with no data at all, don't bother rendering the

--- a/src/js/components/Provenance/Catalogue/Catalogue.tsx
+++ b/src/js/components/Provenance/Catalogue/Catalogue.tsx
@@ -72,7 +72,7 @@ const Catalogue = () => {
         <div className="flex-1 min-w-0">
           <CatalogueToolbar
             filteredCount={filtered.length}
-            showFilterToggle={railOverlay}
+            isMobile={railOverlay}
             onOpenFilters={() => setRailOpen(true)}
           />
 

--- a/src/js/components/Provenance/Catalogue/Catalogue.tsx
+++ b/src/js/components/Provenance/Catalogue/Catalogue.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import clsx from 'clsx';
-import { Divider, Empty, Button, Flex, Typography } from 'antd';
+import { Divider, Empty, Button, Flex, Grid, Typography } from 'antd';
 import { useMetadata } from '@/features/metadata/hooks';
 import { useCatalogueFilter, useCatalogueState } from '@/features/catalogue/hooks';
 import { useAppDispatch } from '@/hooks';
@@ -17,6 +17,7 @@ import CatalogueInsights from './CatalogueInsights';
 import Dataset from '@/components/Provenance/Dataset';
 
 const { Text } = Typography;
+const { useBreakpoint } = Grid;
 
 const Catalogue = () => {
   useCatalogueUrlSync();
@@ -26,6 +27,12 @@ const Catalogue = () => {
   const { clearAll } = useCatalogueUrlActions();
   const { projects, projectsStatus, projectsError } = useMetadata();
   const { view, insightsOpen } = useCatalogueState();
+
+  // Below the `lg` breakpoint the rail becomes a slide-over drawer instead of an inline sticky column,
+  // mirroring the overlay/collapsed pattern SiteSider uses for the Search feature's sidebar.
+  const breakpoints = useBreakpoint();
+  const railOverlay = !breakpoints.lg;
+  const [railOpen, setRailOpen] = useState(false);
 
   const allDatasets = useMemo(
     () => projects.flatMap((p) => (p.datasets ?? []).map((d) => ({ dataset: d, project: p }))),
@@ -53,11 +60,21 @@ const Catalogue = () => {
       {/* Body: rail + main */}
       <Flex gap={20} align="flex-start">
         {/* Left: facet rail */}
-        <CatalogueRail totalCount={filtered.length} facetOptions={facetOptions} />
+        <CatalogueRail
+          totalCount={filtered.length}
+          facetOptions={facetOptions}
+          overlay={railOverlay}
+          open={!railOverlay || railOpen}
+          onClose={() => setRailOpen(false)}
+        />
 
         {/* Right: toolbar + insights + grid */}
         <div className="flex-1 min-w-0">
-          <CatalogueToolbar filteredCount={filtered.length} />
+          <CatalogueToolbar
+            filteredCount={filtered.length}
+            showFilterToggle={railOverlay}
+            onOpenFilters={() => setRailOpen(true)}
+          />
 
           {insightsOpen && (
             <div className="catalogue-insights-container">

--- a/src/js/components/Provenance/Catalogue/Catalogue.tsx
+++ b/src/js/components/Provenance/Catalogue/Catalogue.tsx
@@ -5,8 +5,8 @@ import { useMetadata } from '@/features/metadata/hooks';
 import { useCatalogueFilter, useCatalogueState } from '@/features/catalogue/hooks';
 import { useAppDispatch } from '@/hooks';
 import { useTranslationFn } from '@/hooks';
-import { clearAll, setProjectColors } from '@/features/catalogue/catalogue.store';
-import { useCatalogueUrlSync } from '@/features/catalogue/useCatalogueUrlSync';
+import { setProjectColors } from '@/features/catalogue/catalogue.store';
+import { useCatalogueUrlSync, useCatalogueUrlActions } from '@/features/catalogue/useCatalogueUrlSync';
 import { assignColors } from '@/features/catalogue/hooks';
 import { RequestStatus } from '@/types/requests';
 import Error from '@Util/Error';
@@ -23,6 +23,7 @@ const Catalogue = () => {
 
   const t = useTranslationFn();
   const dispatch = useAppDispatch();
+  const { clearAll } = useCatalogueUrlActions();
   const { projects, projectsStatus, projectsError } = useMetadata();
   const { view, insightsOpen } = useCatalogueState();
 
@@ -72,7 +73,7 @@ const Catalogue = () => {
 
           {filtered.length === 0 ? (
             <Empty description={t('catalogue.datasets.empty')}>
-              <Button type="primary" onClick={() => dispatch(clearAll())}>
+              <Button type="primary" onClick={clearAll}>
                 {t('catalogue.datasets.reset_filters')}
               </Button>
             </Empty>

--- a/src/js/components/Provenance/Catalogue/CatalogueBanner.tsx
+++ b/src/js/components/Provenance/Catalogue/CatalogueBanner.tsx
@@ -65,7 +65,7 @@ const CatalogueBanner = ({ filteredDatasets }: CatalogueBannerProps) => {
             <AboutContent />
           </div>
         )}
-        <Space size={28} wrap>
+        <Space size={[28, 6]} wrap>
           <StatItem
             icon={<DatabaseOutlined />}
             value={fmt(datasetCount)}

--- a/src/js/components/Provenance/Catalogue/CatalogueInsights.tsx
+++ b/src/js/components/Provenance/Catalogue/CatalogueInsights.tsx
@@ -1,7 +1,7 @@
-import { useAppDispatch } from '@/hooks';
 import { Flex, Typography } from 'antd';
 import { useCatalogueState } from '@/features/catalogue/hooks';
-import { toggleFacetValue, type FacetId } from '@/features/catalogue/catalogue.store';
+import type { FacetId } from '@/features/catalogue/catalogue.store';
+import { useCatalogueUrlActions } from '@/features/catalogue/useCatalogueUrlSync';
 import { useTranslationFn } from '@/hooks';
 import { BarChartOutlined } from '@ant-design/icons';
 import type { DatasetWithProject } from '@/features/catalogue/hooks';
@@ -34,8 +34,8 @@ interface CatalogueInsightsProps {
 
 const CatalogueInsights = ({ filteredDatasets }: CatalogueInsightsProps) => {
   const t = useTranslationFn();
-  const dispatch = useAppDispatch();
   const { sets, projectColors } = useCatalogueState();
+  const { toggleFacetValue } = useCatalogueUrlActions();
 
   const statusData = buildCounts(filteredDatasets, ({ dataset }) => [normaliseStatus(dataset.study_status)]);
   const typeData = buildCounts(filteredDatasets, ({ dataset }) => dataset.domain ?? []);
@@ -46,7 +46,7 @@ const CatalogueInsights = ({ filteredDatasets }: CatalogueInsightsProps) => {
   const keywordColors = assignColors(keywordData.slice(0, 5).map((d) => d.name));
 
   const handleClick = (facetId: FacetId, value: string) => {
-    dispatch(toggleFacetValue({ facet: facetId, value }));
+    toggleFacetValue(facetId, value);
   };
 
   return (

--- a/src/js/components/Provenance/Catalogue/CatalogueRail.tsx
+++ b/src/js/components/Provenance/Catalogue/CatalogueRail.tsx
@@ -5,7 +5,7 @@ import { toggleFacetCollapse, type FacetId } from '@/features/catalogue/catalogu
 import { useCatalogueUrlActions } from '@/features/catalogue/useCatalogueUrlSync';
 import { useTranslationFn } from '@/hooks';
 import { statusTranslationKey } from '@/features/catalogue/hooks';
-import { CaretDownOutlined, CaretRightOutlined } from '@ant-design/icons';
+import { CaretDownOutlined, CaretRightOutlined, CloseOutlined } from '@ant-design/icons';
 import FilterChip from '@/components/Util/FilterChip';
 
 interface FacetConfig {
@@ -65,35 +65,49 @@ const FacetSection = ({ facet, options, collapsed, onToggleCollapse, onToggleVal
 interface CatalogueRailProps {
   totalCount: number;
   facetOptions: (facetId: FacetId) => { value: string; count: number; selected: boolean }[];
+  /** Below the `lg` breakpoint, the rail renders as a slide-over drawer instead of an inline sticky column. */
+  overlay: boolean;
+  /** Ignored when `overlay` is false (the rail is always visible inline on desktop). */
+  open: boolean;
+  onClose: () => void;
 }
 
-const CatalogueRail = ({ totalCount, facetOptions }: CatalogueRailProps) => {
+const CatalogueRail = ({ totalCount, facetOptions, overlay, open, onClose }: CatalogueRailProps) => {
   const t = useTranslationFn();
   const dispatch = useAppDispatch();
   const { collapsedFacets } = useCatalogueState();
   const { toggleFacetValue } = useCatalogueUrlActions();
 
   return (
-    <div className="catalogue-rail">
-      <div className="catalogue-rail__header">
-        <span className="catalogue-rail__title">{t('catalogue.rail.title')}</span>
-        <span className="catalogue-rail__count">
-          {totalCount} {t('entities.dataset', { count: totalCount }).toLowerCase()}
-        </span>
+    <>
+      {overlay && open && <div className="catalogue-rail-backdrop" onClick={onClose} aria-hidden />}
+      <div className={clsx('catalogue-rail', overlay && 'catalogue-rail--overlay', open && 'catalogue-rail--open')}>
+        <div className="catalogue-rail__header">
+          <span className="catalogue-rail__title">{t('catalogue.rail.title')}</span>
+          {overlay ? (
+            <button className="catalogue-rail__close" onClick={onClose} aria-label={t('catalogue.rail.close')}>
+              <CloseOutlined />
+            </button>
+          ) : (
+            <span className="catalogue-rail__count">
+              {totalCount} {t('entities.dataset', { count: totalCount }).toLowerCase()}
+            </span>
+          )}
+        </div>
+        <div>
+          {FACETS.map((facet) => (
+            <FacetSection
+              key={facet.id}
+              facet={facet}
+              options={facetOptions(facet.id)}
+              collapsed={collapsedFacets.includes(facet.id)}
+              onToggleCollapse={() => dispatch(toggleFacetCollapse(facet.id))}
+              onToggleValue={(value) => toggleFacetValue(facet.id, value)}
+            />
+          ))}
+        </div>
       </div>
-      <div>
-        {FACETS.map((facet) => (
-          <FacetSection
-            key={facet.id}
-            facet={facet}
-            options={facetOptions(facet.id)}
-            collapsed={collapsedFacets.includes(facet.id)}
-            onToggleCollapse={() => dispatch(toggleFacetCollapse(facet.id))}
-            onToggleValue={(value) => toggleFacetValue(facet.id, value)}
-          />
-        ))}
-      </div>
-    </div>
+    </>
   );
 };
 

--- a/src/js/components/Provenance/Catalogue/CatalogueRail.tsx
+++ b/src/js/components/Provenance/Catalogue/CatalogueRail.tsx
@@ -4,7 +4,7 @@ import { useCatalogueState } from '@/features/catalogue/hooks';
 import { toggleFacetCollapse, type FacetId } from '@/features/catalogue/catalogue.store';
 import { useCatalogueUrlActions } from '@/features/catalogue/useCatalogueUrlSync';
 import { useTranslationFn } from '@/hooks';
-import { statusTranslationKey } from '@/features/catalogue/hooks';
+import { statusTranslationKey, facetTranslationKey } from '@/features/catalogue/hooks';
 import FilterChip from '@/components/Util/FilterChip';
 import FacetSider, { type FacetSiderSection } from '@/components/Util/FacetSider';
 
@@ -43,7 +43,7 @@ const CatalogueRail = ({ totalCount, facetOptions, overlay, open, onClose }: Cat
     .filter(({ options }) => options.length > 0)
     .map(({ facet, options }) => ({
       id: facet.id,
-      label: t(`catalogue.facets.${facet.id}`),
+      label: t(facetTranslationKey(facet.id)),
       collapsed: collapsedFacets.includes(facet.id),
       onToggleCollapse: () => dispatch(toggleFacetCollapse(facet.id)),
       render: () => (

--- a/src/js/components/Provenance/Catalogue/CatalogueRail.tsx
+++ b/src/js/components/Provenance/Catalogue/CatalogueRail.tsx
@@ -1,7 +1,8 @@
 import clsx from 'clsx';
 import { useAppDispatch } from '@/hooks';
 import { useCatalogueState } from '@/features/catalogue/hooks';
-import { toggleFacetValue, toggleFacetCollapse, type FacetId } from '@/features/catalogue/catalogue.store';
+import { toggleFacetCollapse, type FacetId } from '@/features/catalogue/catalogue.store';
+import { useCatalogueUrlActions } from '@/features/catalogue/useCatalogueUrlSync';
 import { useTranslationFn } from '@/hooks';
 import { statusTranslationKey } from '@/features/catalogue/hooks';
 import { CaretDownOutlined, CaretRightOutlined } from '@ant-design/icons';
@@ -70,6 +71,7 @@ const CatalogueRail = ({ totalCount, facetOptions }: CatalogueRailProps) => {
   const t = useTranslationFn();
   const dispatch = useAppDispatch();
   const { collapsedFacets } = useCatalogueState();
+  const { toggleFacetValue } = useCatalogueUrlActions();
 
   return (
     <div className="catalogue-rail">
@@ -87,7 +89,7 @@ const CatalogueRail = ({ totalCount, facetOptions }: CatalogueRailProps) => {
             options={facetOptions(facet.id)}
             collapsed={collapsedFacets.includes(facet.id)}
             onToggleCollapse={() => dispatch(toggleFacetCollapse(facet.id))}
-            onToggleValue={(value) => dispatch(toggleFacetValue({ facet: facet.id, value }))}
+            onToggleValue={(value) => toggleFacetValue(facet.id, value)}
           />
         ))}
       </div>

--- a/src/js/components/Provenance/Catalogue/CatalogueRail.tsx
+++ b/src/js/components/Provenance/Catalogue/CatalogueRail.tsx
@@ -5,8 +5,8 @@ import { toggleFacetCollapse, type FacetId } from '@/features/catalogue/catalogu
 import { useCatalogueUrlActions } from '@/features/catalogue/useCatalogueUrlSync';
 import { useTranslationFn } from '@/hooks';
 import { statusTranslationKey } from '@/features/catalogue/hooks';
-import { CaretDownOutlined, CaretRightOutlined, CloseOutlined } from '@ant-design/icons';
 import FilterChip from '@/components/Util/FilterChip';
+import FacetSider, { type FacetSiderSection } from '@/components/Util/FacetSider';
 
 interface FacetConfig {
   id: FacetId;
@@ -22,45 +22,6 @@ const FACETS: FacetConfig[] = [
   { id: 'statuses' },
   { id: 'keywords', scroll: true },
 ];
-
-interface FacetSectionProps {
-  facet: FacetConfig;
-  options: { value: string; count: number; selected: boolean }[];
-  collapsed: boolean;
-  onToggleCollapse: () => void;
-  onToggleValue: (value: string) => void;
-}
-
-const FacetSection = ({ facet, options, collapsed, onToggleCollapse, onToggleValue }: FacetSectionProps) => {
-  const t = useTranslationFn();
-  if (options.length === 0) return null;
-
-  return (
-    <div className={clsx('facet-section', !collapsed && 'facet-section--expanded')}>
-      <button className="facet-head" onClick={onToggleCollapse}>
-        <span className="facet-head__label">{t(`catalogue.facets.${facet.id}`)}</span>
-        {collapsed ? (
-          <CaretRightOutlined className="facet-head__icon" />
-        ) : (
-          <CaretDownOutlined className="facet-head__icon" />
-        )}
-      </button>
-      {!collapsed && (
-        <div className={clsx('facet-chips', facet.scroll && 'facet-chips--scroll')}>
-          {options.map(({ value, count, selected }) => (
-            <FilterChip
-              key={value}
-              label={facet.id === 'statuses' ? t(statusTranslationKey(value)) : value}
-              count={count}
-              selected={selected}
-              onClick={() => onToggleValue(value)}
-            />
-          ))}
-        </div>
-      )}
-    </div>
-  );
-};
 
 interface CatalogueRailProps {
   totalCount: number;
@@ -78,36 +39,39 @@ const CatalogueRail = ({ totalCount, facetOptions, overlay, open, onClose }: Cat
   const { collapsedFacets } = useCatalogueState();
   const { toggleFacetValue } = useCatalogueUrlActions();
 
-  return (
-    <>
-      {overlay && open && <div className="catalogue-rail-backdrop" onClick={onClose} aria-hidden />}
-      <div className={clsx('catalogue-rail', overlay && 'catalogue-rail--overlay', open && 'catalogue-rail--open')}>
-        <div className="catalogue-rail__header">
-          <span className="catalogue-rail__title">{t('catalogue.rail.title')}</span>
-          {overlay ? (
-            <button className="catalogue-rail__close" onClick={onClose} aria-label={t('catalogue.rail.close')}>
-              <CloseOutlined />
-            </button>
-          ) : (
-            <span className="catalogue-rail__count">
-              {totalCount} {t('entities.dataset', { count: totalCount }).toLowerCase()}
-            </span>
-          )}
-        </div>
-        <div>
-          {FACETS.map((facet) => (
-            <FacetSection
-              key={facet.id}
-              facet={facet}
-              options={facetOptions(facet.id)}
-              collapsed={collapsedFacets.includes(facet.id)}
-              onToggleCollapse={() => dispatch(toggleFacetCollapse(facet.id))}
-              onToggleValue={(value) => toggleFacetValue(facet.id, value)}
+  const sections: FacetSiderSection[] = FACETS.map((facet) => ({ facet, options: facetOptions(facet.id) }))
+    .filter(({ options }) => options.length > 0)
+    .map(({ facet, options }) => ({
+      id: facet.id,
+      label: t(`catalogue.facets.${facet.id}`),
+      collapsed: collapsedFacets.includes(facet.id),
+      onToggleCollapse: () => dispatch(toggleFacetCollapse(facet.id)),
+      render: () => (
+        <div className={clsx('facet-chips', facet.scroll && 'facet-chips--scroll')}>
+          {options.map(({ value, count, selected }) => (
+            <FilterChip
+              key={value}
+              label={facet.id === 'statuses' ? t(statusTranslationKey(value)) : value}
+              count={count}
+              selected={selected}
+              onClick={() => toggleFacetValue(facet.id, value)}
             />
           ))}
         </div>
-      </div>
-    </>
+      ),
+    }));
+
+  return (
+    <FacetSider
+      title={t('catalogue.rail.title')}
+      countLabel={`${totalCount} ${t('entities.dataset', { count: totalCount }).toLowerCase()}`}
+      closeLabel={t('catalogue.rail.close')}
+      overlay={overlay}
+      open={open}
+      onClose={onClose}
+      sections={sections}
+      classPrefix="catalogue-rail"
+    />
   );
 };
 

--- a/src/js/components/Provenance/Catalogue/CatalogueToolbar.tsx
+++ b/src/js/components/Provenance/Catalogue/CatalogueToolbar.tsx
@@ -8,7 +8,7 @@ import {
   SearchOutlined,
   SwapOutlined,
 } from '@ant-design/icons';
-import { useCatalogueState } from '@/features/catalogue/hooks';
+import { useCatalogueState, facetTranslationKey } from '@/features/catalogue/hooks';
 import { toggleInsights, type SortKey, type FacetId } from '@/features/catalogue/catalogue.store';
 import { useCatalogueUrlActions } from '@/features/catalogue/useCatalogueUrlSync';
 import { useTranslationFn } from '@/hooks';
@@ -23,16 +23,6 @@ const SORT_OPTIONS: { value: SortKey; label: string }[] = [
   { value: 'individuals_desc', label: 'catalogue.toolbar.sort.most_individuals' },
   { value: 'biosamples_desc', label: 'catalogue.toolbar.sort.most_biosamples' },
 ];
-
-const FACET_LABELS: Record<FacetId, string> = {
-  projects: 'catalogue.facets.projects',
-  dataTypes: 'catalogue.facets.dataTypes',
-  taxa: 'catalogue.facets.taxa',
-  access: 'catalogue.facets.access',
-  licenses: 'catalogue.facets.licenses',
-  statuses: 'catalogue.facets.statuses',
-  keywords: 'catalogue.facets.keywords',
-};
 
 interface CatalogueToolbarProps {
   filteredCount: number;
@@ -52,7 +42,7 @@ const CatalogueToolbar = ({ filteredCount, isMobile, onOpenFilters }: CatalogueT
     values.forEach((v) =>
       pills.push({
         key: `${facet}-${v}`,
-        facetLabel: FACET_LABELS[facet],
+        facetLabel: facetTranslationKey(facet),
         label: v,
         onClose: () => toggleFacetValue(facet, v),
       })
@@ -62,7 +52,7 @@ const CatalogueToolbar = ({ filteredCount, isMobile, onOpenFilters }: CatalogueT
   if (q) {
     pills.push({
       key: 'keywords-__q__',
-      facetLabel: FACET_LABELS['keywords'],
+      facetLabel: facetTranslationKey('keywords'),
       label: `"${q}"`,
       onClose: () => setSearch(''),
     });

--- a/src/js/components/Provenance/Catalogue/CatalogueToolbar.tsx
+++ b/src/js/components/Provenance/Catalogue/CatalogueToolbar.tsx
@@ -2,16 +2,8 @@ import { useAppDispatch } from '@/hooks';
 import { Button, Flex, Input, Select, Segmented, Typography } from 'antd';
 import { AppstoreOutlined, BarsOutlined, BarChartOutlined, SearchOutlined } from '@ant-design/icons';
 import { useCatalogueState } from '@/features/catalogue/hooks';
-import {
-  setSearch,
-  setSort,
-  setView,
-  toggleInsights,
-  toggleFacetValue,
-  clearAll,
-  type SortKey,
-  type FacetId,
-} from '@/features/catalogue/catalogue.store';
+import { toggleInsights, type SortKey, type FacetId } from '@/features/catalogue/catalogue.store';
+import { useCatalogueUrlActions } from '@/features/catalogue/useCatalogueUrlSync';
 import { useTranslationFn } from '@/hooks';
 import ActiveFilterTags from '@/components/Util/ActiveFilterTags';
 
@@ -43,6 +35,7 @@ const CatalogueToolbar = ({ filteredCount }: CatalogueToolbarProps) => {
   const t = useTranslationFn();
   const dispatch = useAppDispatch();
   const { q, sets, sort, view, insightsOpen } = useCatalogueState();
+  const { setSearch, setSort, setView, toggleFacetValue, clearAll } = useCatalogueUrlActions();
 
   const pills: { key: string; facetLabel: string; label: string; onClose: () => void }[] = [];
   (Object.entries(sets) as [FacetId, string[]][]).forEach(([facet, values]) => {
@@ -51,7 +44,7 @@ const CatalogueToolbar = ({ filteredCount }: CatalogueToolbarProps) => {
         key: `${facet}-${v}`,
         facetLabel: FACET_LABELS[facet],
         label: v,
-        onClose: () => dispatch(toggleFacetValue({ facet, value: v })),
+        onClose: () => toggleFacetValue(facet, v),
       })
     );
   });
@@ -61,7 +54,7 @@ const CatalogueToolbar = ({ filteredCount }: CatalogueToolbarProps) => {
       key: 'keywords-__q__',
       facetLabel: FACET_LABELS['keywords'],
       label: `"${q}"`,
-      onClose: () => dispatch(setSearch('')),
+      onClose: () => setSearch(''),
     });
   }
 
@@ -73,19 +66,19 @@ const CatalogueToolbar = ({ filteredCount }: CatalogueToolbarProps) => {
           prefix={<SearchOutlined />}
           placeholder={t('catalogue.toolbar.search_placeholder')}
           value={q}
-          onChange={(e) => dispatch(setSearch(e.target.value))}
+          onChange={(e) => setSearch(e.target.value)}
           className="catalogue-search-input"
           allowClear
         />
         <Select<SortKey>
           value={sort}
-          onChange={(v) => dispatch(setSort(v))}
+          onChange={(v) => setSort(v)}
           className="catalogue-sort-select"
           options={SORT_OPTIONS.map((o) => ({ value: o.value, label: t(o.label) }))}
         />
         <Segmented
           value={view}
-          onChange={(v) => dispatch(setView(v as 'grid' | 'list'))}
+          onChange={(v) => setView(v as 'grid' | 'list')}
           options={[
             { value: 'grid', icon: <AppstoreOutlined /> },
             { value: 'list', icon: <BarsOutlined /> },
@@ -111,7 +104,7 @@ const CatalogueToolbar = ({ filteredCount }: CatalogueToolbarProps) => {
       </Flex>
 
       {/* Row 3: active filter pills */}
-      <ActiveFilterTags pills={pills} onClearAll={() => dispatch(clearAll())} />
+      <ActiveFilterTags pills={pills} onClearAll={clearAll} />
     </Flex>
   );
 };

--- a/src/js/components/Provenance/Catalogue/CatalogueToolbar.tsx
+++ b/src/js/components/Provenance/Catalogue/CatalogueToolbar.tsx
@@ -1,6 +1,6 @@
 import { useAppDispatch } from '@/hooks';
-import { Button, Flex, Input, Select, Segmented, Typography } from 'antd';
-import { AppstoreOutlined, BarsOutlined, BarChartOutlined, SearchOutlined } from '@ant-design/icons';
+import { Badge, Button, Flex, Input, Select, Segmented, Typography } from 'antd';
+import { AppstoreOutlined, BarsOutlined, BarChartOutlined, FilterOutlined, SearchOutlined } from '@ant-design/icons';
 import { useCatalogueState } from '@/features/catalogue/hooks';
 import { toggleInsights, type SortKey, type FacetId } from '@/features/catalogue/catalogue.store';
 import { useCatalogueUrlActions } from '@/features/catalogue/useCatalogueUrlSync';
@@ -29,9 +29,12 @@ const FACET_LABELS: Record<FacetId, string> = {
 
 interface CatalogueToolbarProps {
   filteredCount: number;
+  /** Whether the rail is a slide-over drawer (below the `lg` breakpoint) rather than always-visible inline. */
+  showFilterToggle: boolean;
+  onOpenFilters: () => void;
 }
 
-const CatalogueToolbar = ({ filteredCount }: CatalogueToolbarProps) => {
+const CatalogueToolbar = ({ filteredCount, showFilterToggle, onOpenFilters }: CatalogueToolbarProps) => {
   const t = useTranslationFn();
   const dispatch = useAppDispatch();
   const { q, sets, sort, view, insightsOpen } = useCatalogueState();
@@ -61,7 +64,14 @@ const CatalogueToolbar = ({ filteredCount }: CatalogueToolbarProps) => {
   return (
     <Flex vertical gap={8}>
       {/* Row 1: search + sort + view */}
-      <Flex gap={8} align="center">
+      <Flex gap={8} align="center" wrap>
+        {showFilterToggle && (
+          <Badge count={pills.length} size="small" offset={[-4, 4]}>
+            <Button icon={<FilterOutlined />} onClick={onOpenFilters}>
+              {t('catalogue.rail.title')}
+            </Button>
+          </Badge>
+        )}
         <Input
           prefix={<SearchOutlined />}
           placeholder={t('catalogue.toolbar.search_placeholder')}

--- a/src/js/components/Provenance/Catalogue/CatalogueToolbar.tsx
+++ b/src/js/components/Provenance/Catalogue/CatalogueToolbar.tsx
@@ -1,6 +1,13 @@
 import { useAppDispatch } from '@/hooks';
-import { Badge, Button, Flex, Input, Select, Segmented, Typography } from 'antd';
-import { AppstoreOutlined, BarsOutlined, BarChartOutlined, FilterOutlined, SearchOutlined } from '@ant-design/icons';
+import { Badge, Button, Dropdown, Flex, Input, Select, Segmented, Typography } from 'antd';
+import {
+  AppstoreOutlined,
+  BarsOutlined,
+  BarChartOutlined,
+  FilterOutlined,
+  SearchOutlined,
+  SwapOutlined,
+} from '@ant-design/icons';
 import { useCatalogueState } from '@/features/catalogue/hooks';
 import { toggleInsights, type SortKey, type FacetId } from '@/features/catalogue/catalogue.store';
 import { useCatalogueUrlActions } from '@/features/catalogue/useCatalogueUrlSync';
@@ -29,12 +36,12 @@ const FACET_LABELS: Record<FacetId, string> = {
 
 interface CatalogueToolbarProps {
   filteredCount: number;
-  /** Whether the rail is a slide-over drawer (below the `lg` breakpoint) rather than always-visible inline. */
-  showFilterToggle: boolean;
+  /** Below the `lg` breakpoint: the rail is a slide-over drawer, sort collapses to an icon button, and the grid/list switch is hidden. */
+  isMobile: boolean;
   onOpenFilters: () => void;
 }
 
-const CatalogueToolbar = ({ filteredCount, showFilterToggle, onOpenFilters }: CatalogueToolbarProps) => {
+const CatalogueToolbar = ({ filteredCount, isMobile, onOpenFilters }: CatalogueToolbarProps) => {
   const t = useTranslationFn();
   const dispatch = useAppDispatch();
   const { q, sets, sort, view, insightsOpen } = useCatalogueState();
@@ -65,7 +72,7 @@ const CatalogueToolbar = ({ filteredCount, showFilterToggle, onOpenFilters }: Ca
     <Flex vertical gap={8}>
       {/* Row 1: search + sort + view */}
       <Flex gap={8} align="center">
-        {showFilterToggle && (
+        {isMobile && (
           <Badge count={pills.length} size="small" offset={[-4, 4]} className="catalogue-toolbar-fixed">
             <Button icon={<FilterOutlined />} onClick={onOpenFilters}>
               {t('catalogue.rail.title')}
@@ -80,21 +87,40 @@ const CatalogueToolbar = ({ filteredCount, showFilterToggle, onOpenFilters }: Ca
           className="catalogue-search-input"
           allowClear
         />
-        <Select<SortKey>
-          value={sort}
-          onChange={(v) => setSort(v)}
-          className="catalogue-sort-select"
-          options={SORT_OPTIONS.map((o) => ({ value: o.value, label: t(o.label) }))}
-        />
-        <Segmented
-          className="catalogue-toolbar-fixed"
-          value={view}
-          onChange={(v) => setView(v as 'grid' | 'list')}
-          options={[
-            { value: 'grid', icon: <AppstoreOutlined /> },
-            { value: 'list', icon: <BarsOutlined /> },
-          ]}
-        />
+        {isMobile ? (
+          <Dropdown
+            trigger={['click']}
+            menu={{
+              selectedKeys: [sort],
+              items: SORT_OPTIONS.map((o) => ({ key: o.value, label: t(o.label) })),
+              onClick: ({ key }) => setSort(key as SortKey),
+            }}
+          >
+            <Button
+              className="catalogue-toolbar-fixed"
+              icon={<SwapOutlined rotate={90} />}
+              aria-label={t('catalogue.toolbar.sort_label')}
+            />
+          </Dropdown>
+        ) : (
+          <Select<SortKey>
+            value={sort}
+            onChange={(v) => setSort(v)}
+            className="catalogue-sort-select"
+            options={SORT_OPTIONS.map((o) => ({ value: o.value, label: t(o.label) }))}
+          />
+        )}
+        {!isMobile && (
+          <Segmented
+            className="catalogue-toolbar-fixed"
+            value={view}
+            onChange={(v) => setView(v as 'grid' | 'list')}
+            options={[
+              { value: 'grid', icon: <AppstoreOutlined /> },
+              { value: 'list', icon: <BarsOutlined /> },
+            ]}
+          />
+        )}
       </Flex>
 
       {/* Row 2: result count + insights toggle */}

--- a/src/js/components/Provenance/Catalogue/CatalogueToolbar.tsx
+++ b/src/js/components/Provenance/Catalogue/CatalogueToolbar.tsx
@@ -64,9 +64,9 @@ const CatalogueToolbar = ({ filteredCount, showFilterToggle, onOpenFilters }: Ca
   return (
     <Flex vertical gap={8}>
       {/* Row 1: search + sort + view */}
-      <Flex gap={8} align="center" wrap>
+      <Flex gap={8} align="center">
         {showFilterToggle && (
-          <Badge count={pills.length} size="small" offset={[-4, 4]}>
+          <Badge count={pills.length} size="small" offset={[-4, 4]} className="catalogue-toolbar-fixed">
             <Button icon={<FilterOutlined />} onClick={onOpenFilters}>
               {t('catalogue.rail.title')}
             </Button>
@@ -87,6 +87,7 @@ const CatalogueToolbar = ({ filteredCount, showFilterToggle, onOpenFilters }: Ca
           options={SORT_OPTIONS.map((o) => ({ value: o.value, label: t(o.label) }))}
         />
         <Segmented
+          className="catalogue-toolbar-fixed"
           value={view}
           onChange={(v) => setView(v as 'grid' | 'list')}
           options={[

--- a/src/js/components/Search/SearchFilters.tsx
+++ b/src/js/components/Search/SearchFilters.tsx
@@ -19,7 +19,6 @@ import type { QueryParamEntries, QueryParamEntry } from '@/features/search/types
 import SearchFilterInput, { type FilterInputValue, SearchFilterInputSkeleton } from './SearchFilterInput';
 import SearchSubForm, { type DefinedSearchSubFormProps } from '@/components/Search/SearchSubForm';
 import FiltersAppliedTag from '@/components/Search/FiltersAppliedTag';
-import ActiveFilterTags, { type ActiveFilterPill } from '@/components/Util/ActiveFilterTags';
 const { Text } = Typography;
 
 const buildValueToEntry =
@@ -38,48 +37,6 @@ const SearchFilters = (props: DefinedSearchSubFormProps) => {
   const entityAndTextQueryParams = useEntityAndTextQueryParams();
 
   const nSearchFilters = useMemo(() => filterSections.flatMap((s) => s.fields).length, [filterSections]);
-
-  const clearAllFilters = () => {
-    const url = buildQueryParamsUrl(pathname, entityAndTextQueryParams);
-    navigate(url, { replace: true });
-  };
-
-  const removeFilterValue = (field: string, value: string) => {
-    const oldValue = filters[field];
-    const remaining = Array.isArray(oldValue) ? oldValue.filter((v) => v !== value) : [];
-    const resetPage = entityAndTextQueryParams.find(([k, _]) => k === TABLE_PAGE_QUERY_PARAM)
-      ? ([[TABLE_PAGE_QUERY_PARAM, '0']] as QueryParamEntries)
-      : [];
-
-    if (Array.isArray(oldValue) && remaining.length > 0) {
-      // Keep the field, drop just this one value.
-      const existingFiltersQP = filtersStateToQueryParamEntries(filters, true).filter(
-        ([k, v]) => k !== field || remaining.includes(v)
-      );
-      const url = buildQueryParamsUrl(pathname, [...existingFiltersQP, ...entityAndTextQueryParams, ...resetPage]);
-      navigate(url, { replace: true });
-      return;
-    }
-
-    // Single value, or the last remaining array value: drop the field entirely.
-    const filtersStateAsQueryParams = filtersStateToQueryParamEntries(filters, true);
-    const url = buildQueryParamsUrl(
-      pathname,
-      combineQueryParamsWithoutKey(filtersStateAsQueryParams, [...entityAndTextQueryParams, ...resetPage], [field])
-    );
-    navigate(url, { replace: true });
-  };
-
-  const pills: ActiveFilterPill[] = [];
-  Object.entries(filters).forEach(([field, value]) => {
-    if (value === null || value === undefined) return;
-    const facetLabel = fields.find((f) => f.id === field)?.definition.title ?? field;
-    const values = Array.isArray(value) ? value : value ? [value] : [];
-    values.forEach((v) => {
-      if (!v) return;
-      pills.push({ key: `${field}-${v}`, facetLabel, label: v, onClose: () => removeFilterValue(field, v) });
-    });
-  });
 
   const [filterInputs, usedFields] = useMemo(() => {
     const filterInputs_: FilterInputValue[] = Object.entries(filters).map(([k, v]) => ({
@@ -108,7 +65,6 @@ const SearchFilters = (props: DefinedSearchSubFormProps) => {
       {...props}
     >
       <Space direction="vertical" size={8} className="w-full">
-        <ActiveFilterTags pills={pills} onClearAll={clearAllFilters} />
         {WAITING_STATES.includes(configStatus) || WAITING_STATES.includes(fieldsStatus) ? (
           <SearchFilterInputSkeleton />
         ) : (

--- a/src/js/components/Search/SearchFilters.tsx
+++ b/src/js/components/Search/SearchFilters.tsx
@@ -19,6 +19,7 @@ import type { QueryParamEntries, QueryParamEntry } from '@/features/search/types
 import SearchFilterInput, { type FilterInputValue, SearchFilterInputSkeleton } from './SearchFilterInput';
 import SearchSubForm, { type DefinedSearchSubFormProps } from '@/components/Search/SearchSubForm';
 import FiltersAppliedTag from '@/components/Search/FiltersAppliedTag';
+import ActiveFilterTags, { type ActiveFilterPill } from '@/components/Util/ActiveFilterTags';
 const { Text } = Typography;
 
 const buildValueToEntry =
@@ -37,6 +38,48 @@ const SearchFilters = (props: DefinedSearchSubFormProps) => {
   const entityAndTextQueryParams = useEntityAndTextQueryParams();
 
   const nSearchFilters = useMemo(() => filterSections.flatMap((s) => s.fields).length, [filterSections]);
+
+  const clearAllFilters = () => {
+    const url = buildQueryParamsUrl(pathname, entityAndTextQueryParams);
+    navigate(url, { replace: true });
+  };
+
+  const removeFilterValue = (field: string, value: string) => {
+    const oldValue = filters[field];
+    const remaining = Array.isArray(oldValue) ? oldValue.filter((v) => v !== value) : [];
+    const resetPage = entityAndTextQueryParams.find(([k, _]) => k === TABLE_PAGE_QUERY_PARAM)
+      ? ([[TABLE_PAGE_QUERY_PARAM, '0']] as QueryParamEntries)
+      : [];
+
+    if (Array.isArray(oldValue) && remaining.length > 0) {
+      // Keep the field, drop just this one value.
+      const existingFiltersQP = filtersStateToQueryParamEntries(filters, true).filter(
+        ([k, v]) => k !== field || remaining.includes(v)
+      );
+      const url = buildQueryParamsUrl(pathname, [...existingFiltersQP, ...entityAndTextQueryParams, ...resetPage]);
+      navigate(url, { replace: true });
+      return;
+    }
+
+    // Single value, or the last remaining array value: drop the field entirely.
+    const filtersStateAsQueryParams = filtersStateToQueryParamEntries(filters, true);
+    const url = buildQueryParamsUrl(
+      pathname,
+      combineQueryParamsWithoutKey(filtersStateAsQueryParams, [...entityAndTextQueryParams, ...resetPage], [field])
+    );
+    navigate(url, { replace: true });
+  };
+
+  const pills: ActiveFilterPill[] = [];
+  Object.entries(filters).forEach(([field, value]) => {
+    if (value === null || value === undefined) return;
+    const facetLabel = fields.find((f) => f.id === field)?.definition.title ?? field;
+    const values = Array.isArray(value) ? value : value ? [value] : [];
+    values.forEach((v) => {
+      if (!v) return;
+      pills.push({ key: `${field}-${v}`, facetLabel, label: v, onClose: () => removeFilterValue(field, v) });
+    });
+  });
 
   const [filterInputs, usedFields] = useMemo(() => {
     const filterInputs_: FilterInputValue[] = Object.entries(filters).map(([k, v]) => ({
@@ -65,6 +108,7 @@ const SearchFilters = (props: DefinedSearchSubFormProps) => {
       {...props}
     >
       <Space direction="vertical" size={8} className="w-full">
+        <ActiveFilterTags pills={pills} onClearAll={clearAllFilters} />
         {WAITING_STATES.includes(configStatus) || WAITING_STATES.includes(fieldsStatus) ? (
           <SearchFilterInputSkeleton />
         ) : (

--- a/src/js/components/SiteSider.tsx
+++ b/src/js/components/SiteSider.tsx
@@ -1,7 +1,8 @@
 import clsx from 'clsx';
-import { Divider, Input, Layout, Typography } from 'antd';
+import { Divider, Input, Layout } from 'antd';
 import { FormOutlined } from '@ant-design/icons';
 import SearchForm from '@/components/Search/SearchForm';
+import FacetSider from '@/components/Util/FacetSider';
 import { useSelectedScope } from '@/features/metadata/hooks';
 import { useTranslationFn } from '@/hooks';
 
@@ -17,7 +18,19 @@ const SiteSider = ({ collapsed, overlay }: { collapsed: boolean; overlay: boolea
         minHeight: scope.project ? 'calc(100vh - var(--header-height) - var(--content-scoped-title-height))' : 0,
       }}
     >
-      <div id="site-sider__inner">
+      <FacetSider
+        id="site-sider__inner"
+        classPrefix="site-sider-shell"
+        overlay={false}
+        open
+        title={
+          scope.project ? undefined : (
+            <>
+              <FormOutlined /> {t('search.text_search')}
+            </>
+          )
+        }
+      >
         {scope.project ? (
           <>
             <SearchForm />
@@ -25,14 +38,9 @@ const SiteSider = ({ collapsed, overlay }: { collapsed: boolean; overlay: boolea
           </>
         ) : (
           // TODO: hook up catalogue search
-          <>
-            <Typography.Title level={3} className="search-sub-form-title">
-              <FormOutlined /> {t('search.text_search')}
-            </Typography.Title>
-            <Input.Search />
-          </>
+          <Input.Search />
         )}
-      </div>
+      </FacetSider>
     </Layout.Sider>
   );
 };

--- a/src/js/components/Util/ActiveFilterTags.tsx
+++ b/src/js/components/Util/ActiveFilterTags.tsx
@@ -1,4 +1,5 @@
 import { Flex, Tag } from 'antd';
+import clsx from 'clsx';
 import { useTranslationFn } from '@/hooks';
 
 export interface ActiveFilterPill {
@@ -11,20 +12,22 @@ export interface ActiveFilterPill {
 interface ActiveFilterTagsProps {
   pills: ActiveFilterPill[];
   onClearAll: () => void;
+  /** Extra class applied to each tag, e.g. for a larger variant on a specific page. */
+  tagClassName?: string;
 }
 
-const ActiveFilterTags = ({ pills, onClearAll }: ActiveFilterTagsProps) => {
+const ActiveFilterTags = ({ pills, onClearAll, tagClassName }: ActiveFilterTagsProps) => {
   const t = useTranslationFn();
   if (pills.length === 0) return null;
   return (
     <Flex wrap gap={4} align="center">
       {pills.map(({ key, facetLabel, label, onClose }) => (
-        <Tag key={key} closable onClose={onClose} className="catalogue-filter-tag">
+        <Tag key={key} closable onClose={onClose} className={clsx('catalogue-filter-tag', tagClassName)}>
           <span className="catalogue-filter-tag__facet-label">{t(facetLabel)}:</span>
           {label}
         </Tag>
       ))}
-      <Tag className="catalogue-clear-tag" onClick={onClearAll}>
+      <Tag className={clsx('catalogue-clear-tag', tagClassName)} onClick={onClearAll}>
         {t('catalogue.toolbar.clear_all')}
       </Tag>
     </Flex>

--- a/src/js/components/Util/FacetSider.tsx
+++ b/src/js/components/Util/FacetSider.tsx
@@ -1,0 +1,78 @@
+import type { ReactNode } from 'react';
+import clsx from 'clsx';
+import { CaretDownOutlined, CaretRightOutlined, CloseOutlined } from '@ant-design/icons';
+
+export interface FacetSiderSection {
+  id: string;
+  label: string;
+  collapsed: boolean;
+  onToggleCollapse: () => void;
+  /** Body content for the section, e.g. chips, a range input, a date picker — the shell doesn't care. */
+  render: () => ReactNode;
+}
+
+export interface FacetSiderProps {
+  title: string;
+  /** Shown in the header in place of the close button when not in overlay mode, e.g. a result count. */
+  countLabel?: ReactNode;
+  closeLabel: string;
+  /** Below some breakpoint, the sider renders as a fixed slide-over drawer instead of an inline column. */
+  overlay: boolean;
+  /** Ignored when `overlay` is false (the sider is always visible inline). */
+  open: boolean;
+  onClose: () => void;
+  sections: FacetSiderSection[];
+  /** BEM-style class prefix, e.g. "catalogue-rail" — drives `{prefix}`, `{prefix}-backdrop`,
+   *  `{prefix}--overlay`, `{prefix}--open`, and `{prefix}__*` header classes. */
+  classPrefix: string;
+}
+
+/**
+ * Generic facet-sidebar shell: header (title + count-or-close) plus a list of collapsible
+ * sections, with an optional overlay/slide-over presentation for narrow viewports. Each section
+ * owns its own collapse state and renders its own body, so the same shell works for the
+ * catalogue's chip facets and (eventually) the Search feature's enum/range/date filters.
+ */
+const FacetSider = ({
+  title,
+  countLabel,
+  closeLabel,
+  overlay,
+  open,
+  onClose,
+  sections,
+  classPrefix,
+}: FacetSiderProps) => (
+  <>
+    {overlay && open && <div className={`${classPrefix}-backdrop`} onClick={onClose} aria-hidden />}
+    <div className={clsx(classPrefix, overlay && `${classPrefix}--overlay`, open && `${classPrefix}--open`)}>
+      <div className={`${classPrefix}__header`}>
+        <span className={`${classPrefix}__title`}>{title}</span>
+        {overlay ? (
+          <button className={`${classPrefix}__close`} onClick={onClose} aria-label={closeLabel}>
+            <CloseOutlined />
+          </button>
+        ) : (
+          countLabel !== undefined && <span className={`${classPrefix}__count`}>{countLabel}</span>
+        )}
+      </div>
+      <div>
+        {sections.map((section) => (
+          <div key={section.id} className={clsx('facet-section', !section.collapsed && 'facet-section--expanded')}>
+            <button className="facet-head" onClick={section.onToggleCollapse}>
+              <span className="facet-head__label">{section.label}</span>
+              {section.collapsed ? (
+                <CaretRightOutlined className="facet-head__icon" />
+              ) : (
+                <CaretDownOutlined className="facet-head__icon" />
+              )}
+            </button>
+            {!section.collapsed && section.render()}
+          </div>
+        ))}
+      </div>
+    </div>
+  </>
+);
+
+export default FacetSider;

--- a/src/js/components/Util/FacetSider.tsx
+++ b/src/js/components/Util/FacetSider.tsx
@@ -12,26 +12,33 @@ export interface FacetSiderSection {
 }
 
 export interface FacetSiderProps {
-  title: string;
+  /** Omit to render no header at all, e.g. when the caller's own content already has a title. */
+  title?: ReactNode;
   /** Shown in the header in place of the close button when not in overlay mode, e.g. a result count. */
   countLabel?: ReactNode;
-  closeLabel: string;
+  /** Required when `overlay` is true (labels the close button); unused otherwise. */
+  closeLabel?: string;
   /** Below some breakpoint, the sider renders as a fixed slide-over drawer instead of an inline column. */
   overlay: boolean;
   /** Ignored when `overlay` is false (the sider is always visible inline). */
   open: boolean;
-  onClose: () => void;
-  sections: FacetSiderSection[];
+  onClose?: () => void;
+  /** Renders as collapsible facet sections. Omit and use `children` for a non-sectioned body (e.g. a form). */
+  sections?: FacetSiderSection[];
+  children?: ReactNode;
   /** BEM-style class prefix, e.g. "catalogue-rail" — drives `{prefix}`, `{prefix}-backdrop`,
    *  `{prefix}--overlay`, `{prefix}--open`, and `{prefix}__*` header classes. */
   classPrefix: string;
+  /** Applied to the outer wrapper div, for callers with existing id-keyed CSS. */
+  id?: string;
 }
 
 /**
- * Generic facet-sidebar shell: header (title + count-or-close) plus a list of collapsible
- * sections, with an optional overlay/slide-over presentation for narrow viewports. Each section
- * owns its own collapse state and renders its own body, so the same shell works for the
- * catalogue's chip facets and (eventually) the Search feature's enum/range/date filters.
+ * Generic facet-sidebar shell: an optional header (title + count-or-close) plus a body, with an
+ * optional overlay/slide-over presentation for narrow viewports. The body is either a list of
+ * collapsible facet sections (`sections`) or arbitrary content (`children`), so the same shell
+ * works for the catalogue's chip facets and the Search feature's sidebar (SearchForm), even
+ * though the two don't share a URL-sync or filter-state model.
  */
 const FacetSider = ({
   title,
@@ -41,36 +48,44 @@ const FacetSider = ({
   open,
   onClose,
   sections,
+  children,
   classPrefix,
+  id,
 }: FacetSiderProps) => (
   <>
     {overlay && open && <div className={`${classPrefix}-backdrop`} onClick={onClose} aria-hidden />}
-    <div className={clsx(classPrefix, overlay && `${classPrefix}--overlay`, open && `${classPrefix}--open`)}>
-      <div className={`${classPrefix}__header`}>
-        <span className={`${classPrefix}__title`}>{title}</span>
-        {overlay ? (
-          <button className={`${classPrefix}__close`} onClick={onClose} aria-label={closeLabel}>
-            <CloseOutlined />
-          </button>
-        ) : (
-          countLabel !== undefined && <span className={`${classPrefix}__count`}>{countLabel}</span>
-        )}
-      </div>
-      <div>
-        {sections.map((section) => (
-          <div key={section.id} className={clsx('facet-section', !section.collapsed && 'facet-section--expanded')}>
-            <button className="facet-head" onClick={section.onToggleCollapse}>
-              <span className="facet-head__label">{section.label}</span>
-              {section.collapsed ? (
-                <CaretRightOutlined className="facet-head__icon" />
-              ) : (
-                <CaretDownOutlined className="facet-head__icon" />
-              )}
+    <div id={id} className={clsx(classPrefix, overlay && `${classPrefix}--overlay`, open && `${classPrefix}--open`)}>
+      {title !== undefined && (
+        <div className={`${classPrefix}__header`}>
+          <span className={`${classPrefix}__title`}>{title}</span>
+          {overlay ? (
+            <button className={`${classPrefix}__close`} onClick={onClose} aria-label={closeLabel}>
+              <CloseOutlined />
             </button>
-            {!section.collapsed && section.render()}
-          </div>
-        ))}
-      </div>
+          ) : (
+            countLabel !== undefined && <span className={`${classPrefix}__count`}>{countLabel}</span>
+          )}
+        </div>
+      )}
+      {sections ? (
+        <div>
+          {sections.map((section) => (
+            <div key={section.id} className={clsx('facet-section', !section.collapsed && 'facet-section--expanded')}>
+              <button className="facet-head" onClick={section.onToggleCollapse}>
+                <span className="facet-head__label">{section.label}</span>
+                {section.collapsed ? (
+                  <CaretRightOutlined className="facet-head__icon" />
+                ) : (
+                  <CaretDownOutlined className="facet-head__icon" />
+                )}
+              </button>
+              {!section.collapsed && section.render()}
+            </div>
+          ))}
+        </div>
+      ) : (
+        children
+      )}
     </div>
   </>
 );

--- a/src/js/features/catalogue/catalogue.store.ts
+++ b/src/js/features/catalogue/catalogue.store.ts
@@ -37,24 +37,13 @@ const initialState: CatalogueState = {
   projectColors: {},
 };
 
+// q, sort, view, and sets are URL-driven: the URL is the source of truth, and useCatalogueUrlSync
+// is the only place that writes them into Redux (via hydrateFromUrl), reacting to navigation.
+// Components mutate them by navigating (see useCatalogueUrlActions), never by dispatching directly.
 const catalogueSlice = createSlice({
   name: 'catalogue',
   initialState,
   reducers: {
-    toggleFacetValue(state, action: PayloadAction<{ facet: FacetId; value: string }>) {
-      const { facet, value } = action.payload;
-      const current = state.sets[facet];
-      state.sets[facet] = current.includes(value) ? current.filter((v) => v !== value) : [...current, value];
-    },
-    setSearch(state, action: PayloadAction<string>) {
-      state.q = action.payload;
-    },
-    setSort(state, action: PayloadAction<SortKey>) {
-      state.sort = action.payload;
-    },
-    setView(state, action: PayloadAction<ViewMode>) {
-      state.view = action.payload;
-    },
     toggleInsights(state) {
       state.insightsOpen = !state.insightsOpen;
     },
@@ -76,22 +65,8 @@ const catalogueSlice = createSlice({
     setProjectColors(state, action: PayloadAction<Record<string, string>>) {
       state.projectColors = action.payload;
     },
-    clearAll(state) {
-      state.q = '';
-      state.sets = { ...EMPTY_SETS };
-    },
   },
 });
 
-export const {
-  toggleFacetValue,
-  setSearch,
-  setSort,
-  setView,
-  toggleInsights,
-  toggleFacetCollapse,
-  hydrateFromUrl,
-  setProjectColors,
-  clearAll,
-} = catalogueSlice.actions;
+export const { toggleInsights, toggleFacetCollapse, hydrateFromUrl, setProjectColors } = catalogueSlice.actions;
 export default catalogueSlice.reducer;

--- a/src/js/features/catalogue/hooks.ts
+++ b/src/js/features/catalogue/hooks.ts
@@ -17,6 +17,9 @@ export function normaliseStatus(raw: string | undefined | null): string {
 /** Builds the i18n key for a normalised status value, e.g., "Unassigned" -> "catalogue.status.unassigned". */
 export const statusTranslationKey = (status: string): string => `catalogue.status.${status.toLowerCase()}`;
 
+/** Builds the i18n key for a facet's label, e.g., "dataTypes" -> "catalogue.facets.dataTypes". */
+export const facetTranslationKey = (facet: FacetId): string => `catalogue.facets.${facet}`;
+
 /** Ordered colour palette used to assign a stable colour per project name. */
 export const PALETTE = ['#1677FF', '#13C2C2', '#722ED1', '#FA8C16', '#52C41A'];
 

--- a/src/js/features/catalogue/useCatalogueUrlSync.ts
+++ b/src/js/features/catalogue/useCatalogueUrlSync.ts
@@ -1,43 +1,33 @@
-import { useCallback, useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useCallback } from 'react';
 import { useAppDispatch } from '@/hooks';
-import { queryParamsWithoutKey, type QueryParamEntries } from '@/utils/queryParams';
-import {
-  hydrateFromUrl,
-  FACET_IDS,
-  type SortKey,
-  type ViewMode,
-  type FacetId,
-  type CatalogueFilterSets,
-} from './catalogue.store';
+import { useUrlFacetSync, type ScalarParam } from '@/hooks/useUrlFacetSync';
+import { useUrlFacetActions } from '@/hooks/useUrlFacetActions';
+import { hydrateFromUrl, FACET_IDS, type SortKey, type ViewMode, type CatalogueFilterSets } from './catalogue.store';
 
-const VALID_SORTS: SortKey[] = ['updated_desc', 'created_desc', 'title_az', 'individuals_desc', 'biosamples_desc'];
-const VALID_VIEWS: ViewMode[] = ['grid', 'list'];
+const SORT_PARAM: ScalarParam<SortKey> = {
+  key: 'sort',
+  defaultValue: 'updated_desc',
+  validValues: ['updated_desc', 'created_desc', 'title_az', 'individuals_desc', 'biosamples_desc'],
+};
+const VIEW_PARAM: ScalarParam<ViewMode> = { key: 'view', defaultValue: 'grid', validValues: ['grid', 'list'] };
+const SCALARS = { sort: SORT_PARAM, view: VIEW_PARAM };
 
 /**
  * The URL is the source of truth for catalogue filters. This hydrates Redux from it on mount
- * and on every subsequent navigation (including browser back/forward), mirroring the pattern
- * used by useSearchRouterAndHandler for the Search feature.
+ * and on every subsequent navigation (including browser back/forward), via the generic
+ * useUrlFacetSync, mirroring the pattern used by useSearchRouterAndHandler for the Search feature.
  */
 export function useCatalogueUrlSync() {
   const dispatch = useAppDispatch();
-  const [searchParams] = useSearchParams();
 
-  useEffect(() => {
-    const rawSort = searchParams.get('sort');
-    const rawView = searchParams.get('view');
-    const sets = Object.fromEntries(
-      FACET_IDS.map((facet) => [facet, searchParams.getAll(facet)])
-    ) as unknown as CatalogueFilterSets;
-    dispatch(
-      hydrateFromUrl({
-        q: searchParams.get('q') ?? '',
-        sort: VALID_SORTS.includes(rawSort as SortKey) ? (rawSort as SortKey) : 'updated_desc',
-        view: VALID_VIEWS.includes(rawView as ViewMode) ? (rawView as ViewMode) : 'grid',
-        sets,
-      })
-    );
-  }, [searchParams, dispatch]);
+  const onHydrate = useCallback(
+    ({ q, sets, scalars }: { q: string; sets: CatalogueFilterSets; scalars: Record<string, string> }) => {
+      dispatch(hydrateFromUrl({ q, sets, sort: scalars.sort as SortKey, view: scalars.view as ViewMode }));
+    },
+    [dispatch]
+  );
+
+  useUrlFacetSync(FACET_IDS, SCALARS, onHydrate);
 }
 
 /**
@@ -48,64 +38,17 @@ export function useCatalogueUrlSync() {
  * as the Search feature, sharing queryParamsWithoutKey from @/utils/queryParams.
  */
 export function useCatalogueUrlActions() {
-  const [, setSearchParams] = useSearchParams();
+  const { setParam, toggleFacetValue, clearAll } = useUrlFacetActions(FACET_IDS);
 
-  const setSearch = useCallback(
-    (q: string) => {
-      setSearchParams(
-        (prev) => {
-          const without = queryParamsWithoutKey([...prev.entries()], 'q');
-          return q ? [...without, ['q', q]] : without;
-        },
-        { replace: true }
-      );
-    },
-    [setSearchParams]
-  );
+  const setSearch = useCallback((q: string) => setParam('q', q), [setParam]);
+  const setSort = useCallback((sort: SortKey) => setParam('sort', sort, SORT_PARAM.defaultValue), [setParam]);
+  const setView = useCallback((view: ViewMode) => setParam('view', view, VIEW_PARAM.defaultValue), [setParam]);
 
-  const setSort = useCallback(
-    (sort: SortKey) => {
-      setSearchParams(
-        (prev) => {
-          const without = queryParamsWithoutKey([...prev.entries()], 'sort');
-          return sort !== 'updated_desc' ? [...without, ['sort', sort]] : without;
-        },
-        { replace: true }
-      );
-    },
-    [setSearchParams]
-  );
-
-  const setView = useCallback(
-    (view: ViewMode) => {
-      setSearchParams(
-        (prev) => {
-          const without = queryParamsWithoutKey([...prev.entries()], 'view');
-          return view !== 'grid' ? [...without, ['view', view]] : without;
-        },
-        { replace: true }
-      );
-    },
-    [setSearchParams]
-  );
-
-  const toggleFacetValue = useCallback(
-    (facet: FacetId, value: string) => {
-      setSearchParams(
-        (prev) => {
-          const entries = [...prev.entries()] as QueryParamEntries;
-          const has = entries.some(([k, v]) => k === facet && v === value);
-          return has ? entries.filter(([k, v]) => !(k === facet && v === value)) : [...entries, [facet, value]];
-        },
-        { replace: true }
-      );
-    },
-    [setSearchParams]
-  );
-
-  const clearAll = useCallback(() => {
-    setSearchParams((prev) => queryParamsWithoutKey([...prev.entries()], ['q', ...FACET_IDS]), { replace: true });
-  }, [setSearchParams]);
-
-  return { setSearch, setSort, setView, toggleFacetValue, clearAll };
+  return {
+    setSearch,
+    setSort,
+    setView,
+    toggleFacetValue,
+    clearAll: useCallback(() => clearAll(['q']), [clearAll]),
+  };
 }

--- a/src/js/features/catalogue/useCatalogueUrlSync.ts
+++ b/src/js/features/catalogue/useCatalogueUrlSync.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useAppDispatch } from '@/hooks';
+import { queryParamsWithoutKey, type QueryParamEntries } from '@/utils/queryParams';
 import {
   hydrateFromUrl,
   FACET_IDS,
@@ -12,10 +13,6 @@ import {
 
 const VALID_SORTS: SortKey[] = ['updated_desc', 'created_desc', 'title_az', 'individuals_desc', 'biosamples_desc'];
 const VALID_VIEWS: ViewMode[] = ['grid', 'list'];
-
-function splitParam(v: string | null): string[] {
-  return v ? v.split(',').filter(Boolean) : [];
-}
 
 /**
  * The URL is the source of truth for catalogue filters. This hydrates Redux from it on mount
@@ -30,7 +27,7 @@ export function useCatalogueUrlSync() {
     const rawSort = searchParams.get('sort');
     const rawView = searchParams.get('view');
     const sets = Object.fromEntries(
-      FACET_IDS.map((facet) => [facet, splitParam(searchParams.get(facet))])
+      FACET_IDS.map((facet) => [facet, searchParams.getAll(facet)])
     ) as unknown as CatalogueFilterSets;
     dispatch(
       hydrateFromUrl({
@@ -46,6 +43,9 @@ export function useCatalogueUrlSync() {
 /**
  * Actions that mutate catalogue filter state by navigating the URL. useCatalogueUrlSync reflects
  * the resulting URL change back into Redux, so components never dispatch filter changes directly.
+ *
+ * Facet values use repeated-key query params (?statuses=Ongoing&statuses=Completed), same encoding
+ * as the Search feature, sharing queryParamsWithoutKey from @/utils/queryParams.
  */
 export function useCatalogueUrlActions() {
   const [, setSearchParams] = useSearchParams();
@@ -54,10 +54,8 @@ export function useCatalogueUrlActions() {
     (q: string) => {
       setSearchParams(
         (prev) => {
-          const next = new URLSearchParams(prev);
-          if (q) next.set('q', q);
-          else next.delete('q');
-          return next;
+          const without = queryParamsWithoutKey([...prev.entries()], 'q');
+          return q ? [...without, ['q', q]] : without;
         },
         { replace: true }
       );
@@ -69,10 +67,8 @@ export function useCatalogueUrlActions() {
     (sort: SortKey) => {
       setSearchParams(
         (prev) => {
-          const next = new URLSearchParams(prev);
-          if (sort !== 'updated_desc') next.set('sort', sort);
-          else next.delete('sort');
-          return next;
+          const without = queryParamsWithoutKey([...prev.entries()], 'sort');
+          return sort !== 'updated_desc' ? [...without, ['sort', sort]] : without;
         },
         { replace: true }
       );
@@ -84,10 +80,8 @@ export function useCatalogueUrlActions() {
     (view: ViewMode) => {
       setSearchParams(
         (prev) => {
-          const next = new URLSearchParams(prev);
-          if (view !== 'grid') next.set('view', view);
-          else next.delete('view');
-          return next;
+          const without = queryParamsWithoutKey([...prev.entries()], 'view');
+          return view !== 'grid' ? [...without, ['view', view]] : without;
         },
         { replace: true }
       );
@@ -99,12 +93,9 @@ export function useCatalogueUrlActions() {
     (facet: FacetId, value: string) => {
       setSearchParams(
         (prev) => {
-          const next = new URLSearchParams(prev);
-          const current = splitParam(next.get(facet));
-          const updated = current.includes(value) ? current.filter((v) => v !== value) : [...current, value];
-          if (updated.length > 0) next.set(facet, updated.join(','));
-          else next.delete(facet);
-          return next;
+          const entries = [...prev.entries()] as QueryParamEntries;
+          const has = entries.some(([k, v]) => k === facet && v === value);
+          return has ? entries.filter(([k, v]) => !(k === facet && v === value)) : [...entries, [facet, value]];
         },
         { replace: true }
       );
@@ -113,15 +104,7 @@ export function useCatalogueUrlActions() {
   );
 
   const clearAll = useCallback(() => {
-    setSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev);
-        next.delete('q');
-        for (const facet of FACET_IDS) next.delete(facet);
-        return next;
-      },
-      { replace: true }
-    );
+    setSearchParams((prev) => queryParamsWithoutKey([...prev.entries()], ['q', ...FACET_IDS]), { replace: true });
   }, [setSearchParams]);
 
   return { setSearch, setSort, setView, toggleFacetValue, clearAll };

--- a/src/js/features/catalogue/useCatalogueUrlSync.ts
+++ b/src/js/features/catalogue/useCatalogueUrlSync.ts
@@ -1,8 +1,14 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useAppDispatch } from '@/hooks';
-import { useCatalogueState } from './hooks';
-import { hydrateFromUrl, FACET_IDS, type SortKey, type ViewMode, type CatalogueFilterSets } from './catalogue.store';
+import {
+  hydrateFromUrl,
+  FACET_IDS,
+  type SortKey,
+  type ViewMode,
+  type FacetId,
+  type CatalogueFilterSets,
+} from './catalogue.store';
 
 const VALID_SORTS: SortKey[] = ['updated_desc', 'created_desc', 'title_az', 'individuals_desc', 'biosamples_desc'];
 const VALID_VIEWS: ViewMode[] = ['grid', 'list'];
@@ -11,13 +17,15 @@ function splitParam(v: string | null): string[] {
   return v ? v.split(',').filter(Boolean) : [];
 }
 
+/**
+ * The URL is the source of truth for catalogue filters. This hydrates Redux from it on mount
+ * and on every subsequent navigation (including browser back/forward), mirroring the pattern
+ * used by useSearchRouterAndHandler for the Search feature.
+ */
 export function useCatalogueUrlSync() {
   const dispatch = useAppDispatch();
-  const state = useCatalogueState();
-  const [searchParams, setSearchParams] = useSearchParams();
-  const skipFirstSync = useRef(true);
+  const [searchParams] = useSearchParams();
 
-  // Mount: read URL → hydrate Redux
   useEffect(() => {
     const rawSort = searchParams.get('sort');
     const rawView = searchParams.get('view');
@@ -32,23 +40,89 @@ export function useCatalogueUrlSync() {
         sets,
       })
     );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [searchParams, dispatch]);
+}
 
-  // Redux → URL (skip initial render to avoid wiping URL before hydration completes)
-  useEffect(() => {
-    if (skipFirstSync.current) {
-      skipFirstSync.current = false;
-      return;
-    }
-    const params: Record<string, string> = {};
-    if (state.q) params['q'] = state.q;
-    if (state.sort !== 'updated_desc') params['sort'] = state.sort;
-    if (state.view !== 'grid') params['view'] = state.view;
-    for (const facet of FACET_IDS) {
-      const vals = state.sets[facet];
-      if (vals.length > 0) params[facet] = vals.join(',');
-    }
-    setSearchParams(params, { replace: true });
-  }, [state.q, state.sort, state.view, state.sets, setSearchParams]);
+/**
+ * Actions that mutate catalogue filter state by navigating the URL. useCatalogueUrlSync reflects
+ * the resulting URL change back into Redux, so components never dispatch filter changes directly.
+ */
+export function useCatalogueUrlActions() {
+  const [, setSearchParams] = useSearchParams();
+
+  const setSearch = useCallback(
+    (q: string) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (q) next.set('q', q);
+          else next.delete('q');
+          return next;
+        },
+        { replace: true }
+      );
+    },
+    [setSearchParams]
+  );
+
+  const setSort = useCallback(
+    (sort: SortKey) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (sort !== 'updated_desc') next.set('sort', sort);
+          else next.delete('sort');
+          return next;
+        },
+        { replace: true }
+      );
+    },
+    [setSearchParams]
+  );
+
+  const setView = useCallback(
+    (view: ViewMode) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (view !== 'grid') next.set('view', view);
+          else next.delete('view');
+          return next;
+        },
+        { replace: true }
+      );
+    },
+    [setSearchParams]
+  );
+
+  const toggleFacetValue = useCallback(
+    (facet: FacetId, value: string) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          const current = splitParam(next.get(facet));
+          const updated = current.includes(value) ? current.filter((v) => v !== value) : [...current, value];
+          if (updated.length > 0) next.set(facet, updated.join(','));
+          else next.delete(facet);
+          return next;
+        },
+        { replace: true }
+      );
+    },
+    [setSearchParams]
+  );
+
+  const clearAll = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete('q');
+        for (const facet of FACET_IDS) next.delete(facet);
+        return next;
+      },
+      { replace: true }
+    );
+  }, [setSearchParams]);
+
+  return { setSearch, setSort, setView, toggleFacetValue, clearAll };
 }

--- a/src/js/features/search/hooks.ts
+++ b/src/js/features/search/hooks.ts
@@ -71,7 +71,7 @@ export const useSearchQueryParams = (): QueryParamEntries => {
 export const useActiveFilterPills = (): { pills: ActiveFilterPill[]; clearAll: () => void } => {
   const { pathname } = useLocation();
   const navigate = useNavigate();
-  const { filters } = useSearchQuery();
+  const { filters, textQuery } = useSearchQuery();
   const fields = useSearchFilterFields();
   const entityAndTextQueryParams = useEntityAndTextQueryParams();
 
@@ -109,8 +109,27 @@ export const useActiveFilterPills = (): { pills: ActiveFilterPill[]; clearAll: (
     [filters, entityAndTextQueryParams, pathname, navigate]
   );
 
+  const clearTextQuery = useCallback(() => {
+    const filtersQP = filtersStateToQueryParamEntries(filters, true);
+    const resetPage = entityAndTextQueryParams.find(([k, _]) => k === TABLE_PAGE_QUERY_PARAM)
+      ? ([[TABLE_PAGE_QUERY_PARAM, '0']] as QueryParamEntries)
+      : [];
+    const url = buildQueryParamsUrl(
+      pathname,
+      combineQueryParamsWithoutKey(
+        filtersQP,
+        [...entityAndTextQueryParams, ...resetPage],
+        [TEXT_QUERY_PARAM, TEXT_QUERY_TYPE_PARAM]
+      )
+    );
+    navigate(url, { replace: true });
+  }, [filters, entityAndTextQueryParams, pathname, navigate]);
+
   const pills = useMemo(() => {
     const p: ActiveFilterPill[] = [];
+    if (textQuery) {
+      p.push({ key: '__text_query__', facetLabel: 'search.text_search', label: textQuery, onClose: clearTextQuery });
+    }
     Object.entries(filters).forEach(([field, value]) => {
       if (value === null || value === undefined) return;
       const facetLabel = fields.find((f) => f.id === field)?.definition.title ?? field;
@@ -121,7 +140,7 @@ export const useActiveFilterPills = (): { pills: ActiveFilterPill[]; clearAll: (
       });
     });
     return p;
-  }, [filters, fields, removeFilterValue]);
+  }, [textQuery, clearTextQuery, filters, fields, removeFilterValue]);
 
   return { pills, clearAll };
 };

--- a/src/js/features/search/hooks.ts
+++ b/src/js/features/search/hooks.ts
@@ -1,6 +1,8 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useAppSelector } from '@/hooks';
 import { useScopeQueryData } from '@/hooks/censorship';
+import type { ActiveFilterPill } from '@/components/Util/ActiveFilterTags';
 import {
   ENTITY_QUERY_PARAM,
   TABLE_PAGE_QUERY_PARAM,
@@ -9,7 +11,12 @@ import {
   TEXT_QUERY_TYPE_PARAM,
 } from './constants';
 import type { QueryParamEntries, SearchFieldAndOptions } from './types';
-import { bentoKatsuEntityToResultsDataEntity, filtersStateToQueryParamEntries } from './utils';
+import {
+  bentoKatsuEntityToResultsDataEntity,
+  buildQueryParamsUrl,
+  combineQueryParamsWithoutKey,
+  filtersStateToQueryParamEntries,
+} from './utils';
 
 export const useSearchQuery = () => useAppSelector((state) => state.query);
 
@@ -54,6 +61,69 @@ export const useSearchQueryParams = (): QueryParamEntries => {
   const { filters } = useSearchQuery();
   const otherQueryParams = useEntityAndTextQueryParams();
   return useMemo(() => [...filtersStateToQueryParamEntries(filters), ...otherQueryParams], [filters, otherQueryParams]);
+};
+
+/**
+ * Active-filter pills (for display outside the sidebar, e.g. between the About section and the count
+ * cards on the overview page) plus the actions to remove one filter value or clear all filters. Shared
+ * with SearchFilters (the sidebar's own filter-editing form) so both surfaces navigate the URL the same way.
+ */
+export const useActiveFilterPills = (): { pills: ActiveFilterPill[]; clearAll: () => void } => {
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+  const { filters } = useSearchQuery();
+  const fields = useSearchFilterFields();
+  const entityAndTextQueryParams = useEntityAndTextQueryParams();
+
+  const clearAll = useCallback(() => {
+    const url = buildQueryParamsUrl(pathname, entityAndTextQueryParams);
+    navigate(url, { replace: true });
+  }, [pathname, entityAndTextQueryParams, navigate]);
+
+  const removeFilterValue = useCallback(
+    (field: string, value: string) => {
+      const oldValue = filters[field];
+      const remaining = Array.isArray(oldValue) ? oldValue.filter((v) => v !== value) : [];
+      const resetPage = entityAndTextQueryParams.find(([k, _]) => k === TABLE_PAGE_QUERY_PARAM)
+        ? ([[TABLE_PAGE_QUERY_PARAM, '0']] as QueryParamEntries)
+        : [];
+
+      if (Array.isArray(oldValue) && remaining.length > 0) {
+        // Keep the field, drop just this one value.
+        const existingFiltersQP = filtersStateToQueryParamEntries(filters, true).filter(
+          ([k, v]) => k !== field || remaining.includes(v)
+        );
+        const url = buildQueryParamsUrl(pathname, [...existingFiltersQP, ...entityAndTextQueryParams, ...resetPage]);
+        navigate(url, { replace: true });
+        return;
+      }
+
+      // Single value, or the last remaining array value: drop the field entirely.
+      const filtersStateAsQueryParams = filtersStateToQueryParamEntries(filters, true);
+      const url = buildQueryParamsUrl(
+        pathname,
+        combineQueryParamsWithoutKey(filtersStateAsQueryParams, [...entityAndTextQueryParams, ...resetPage], [field])
+      );
+      navigate(url, { replace: true });
+    },
+    [filters, entityAndTextQueryParams, pathname, navigate]
+  );
+
+  const pills = useMemo(() => {
+    const p: ActiveFilterPill[] = [];
+    Object.entries(filters).forEach(([field, value]) => {
+      if (value === null || value === undefined) return;
+      const facetLabel = fields.find((f) => f.id === field)?.definition.title ?? field;
+      const values = Array.isArray(value) ? value : value ? [value] : [];
+      values.forEach((v) => {
+        if (!v) return;
+        p.push({ key: `${field}-${v}`, facetLabel, label: v, onClose: () => removeFilterValue(field, v) });
+      });
+    });
+    return p;
+  }, [filters, fields, removeFilterValue]);
+
+  return { pills, clearAll };
 };
 
 export const useSearchableFields = () => {

--- a/src/js/features/search/types.ts
+++ b/src/js/features/search/types.ts
@@ -6,8 +6,7 @@ import type { JSONType } from '@/types/json';
 
 export type FtsQueryType = 'plain' | 'phrase' | 'websearch' | 'trigram';
 
-export type QueryParamEntry = [string, string];
-export type QueryParamEntries = QueryParamEntry[];
+export type { QueryParamEntry, QueryParamEntries } from '@/utils/queryParams';
 
 export type FilterValue = string | string[] | null;
 export type FiltersState = Record<string, FilterValue>;

--- a/src/js/features/search/utils.ts
+++ b/src/js/features/search/utils.ts
@@ -2,24 +2,7 @@ import type { BentoCountEntity, BentoKatsuEntity, ResultsDataEntity } from '@/ty
 import type { QueryState } from './query.store';
 import type { FiltersState, QueryParamEntries } from './types';
 
-export const queryParamsWithoutKey = (qp: QueryParamEntries, key: string | string[]): QueryParamEntries => {
-  if (typeof key === 'string') {
-    return qp.filter(([k, _]) => k !== key);
-  } else {
-    return qp.filter(([k, _]) => !key.includes(k));
-  }
-};
-
-export const combineQueryParamsWithoutKey = (
-  qp1: QueryParamEntries,
-  qp2: QueryParamEntries,
-  key: string | string[]
-): QueryParamEntries => queryParamsWithoutKey([...qp1, ...qp2], key);
-
-export const buildQueryParamsUrl = (pathName: string, queryParamEntries?: QueryParamEntries): string => {
-  if (!queryParamEntries || !Object.keys(queryParamEntries).length) return pathName;
-  return `${pathName}?${new URLSearchParams(queryParamEntries).toString()}`;
-};
+export { queryParamsWithoutKey, combineQueryParamsWithoutKey, buildQueryParamsUrl } from '@/utils/queryParams';
 
 /**
  * Returns whether two filter states are equal for the purpose of state-setting (first boolean) and whether they're

--- a/src/js/hooks/useUrlFacetActions.ts
+++ b/src/js/hooks/useUrlFacetActions.ts
@@ -1,0 +1,51 @@
+import { useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { queryParamsWithoutKey, type QueryParamEntries } from '@/utils/queryParams';
+
+/**
+ * Generic URL-navigation actions for a facet-filtered listing: toggling a value within a
+ * repeated-key facet param, setting/clearing a single scalar param, and clearing everything.
+ * Pairs with {@link useUrlFacetSync}, which reflects the resulting URL back into a feature's
+ * own store. Components should call these instead of dispatching filter changes directly.
+ */
+export function useUrlFacetActions<FacetId extends string>(facetIds: readonly FacetId[]) {
+  const [, setSearchParams] = useSearchParams();
+
+  const setParam = useCallback(
+    (key: string, value: string, defaultValue = '') => {
+      setSearchParams(
+        (prev) => {
+          const without = queryParamsWithoutKey([...prev.entries()], key);
+          return value !== defaultValue && value !== '' ? [...without, [key, value]] : without;
+        },
+        { replace: true }
+      );
+    },
+    [setSearchParams]
+  );
+
+  const toggleFacetValue = useCallback(
+    (facet: FacetId, value: string) => {
+      setSearchParams(
+        (prev) => {
+          const entries = [...prev.entries()] as QueryParamEntries;
+          const has = entries.some(([k, v]) => k === facet && v === value);
+          return has ? entries.filter(([k, v]) => !(k === facet && v === value)) : [...entries, [facet, value]];
+        },
+        { replace: true }
+      );
+    },
+    [setSearchParams]
+  );
+
+  const clearAll = useCallback(
+    (extraKeys: string[] = []) => {
+      setSearchParams((prev) => queryParamsWithoutKey([...prev.entries()], [...extraKeys, ...facetIds]), {
+        replace: true,
+      });
+    },
+    [setSearchParams, facetIds]
+  );
+
+  return { setParam, toggleFacetValue, clearAll };
+}

--- a/src/js/hooks/useUrlFacetSync.ts
+++ b/src/js/hooks/useUrlFacetSync.ts
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+export interface ScalarParam<T extends string> {
+  /** Query-string key, e.g. "sort". */
+  key: string;
+  defaultValue: T;
+  validValues: readonly T[];
+}
+
+export interface UrlFacetHydrate<FacetId extends string> {
+  q: string;
+  sets: Record<FacetId, string[]>;
+  scalars: Record<string, string>;
+}
+
+/**
+ * Parses facet sets (repeated-key params, e.g. ?statuses=Ongoing&statuses=Completed) and scalar
+ * params (e.g. ?sort=title_az) out of the URL on mount and on every subsequent navigation, and
+ * hands the parsed result to `onHydrate`. The URL is the source of truth; callers write the
+ * result into their own store rather than dispatching filter changes directly.
+ *
+ * `facetIds` and `scalars` must be stable references (module-level constants) since they're
+ * effect dependencies; `onHydrate` should be a stable callback (e.g. `dispatch(hydrateFromUrl(...))`
+ * wrapped in `useCallback`, or the dispatch function itself).
+ */
+export function useUrlFacetSync<FacetId extends string>(
+  facetIds: readonly FacetId[],
+  scalars: Record<string, ScalarParam<string>>,
+  onHydrate: (parsed: UrlFacetHydrate<FacetId>) => void
+) {
+  const [searchParams] = useSearchParams();
+
+  useEffect(() => {
+    const sets = Object.fromEntries(facetIds.map((id) => [id, searchParams.getAll(id)])) as Record<FacetId, string[]>;
+    const parsedScalars = Object.fromEntries(
+      Object.entries(scalars).map(([name, cfg]) => {
+        const raw = searchParams.get(cfg.key);
+        return [name, raw !== null && cfg.validValues.includes(raw) ? raw : cfg.defaultValue];
+      })
+    );
+    onHydrate({ q: searchParams.get('q') ?? '', sets, scalars: parsedScalars });
+  }, [searchParams, facetIds, scalars, onHydrate]);
+}

--- a/src/js/utils/queryParams.ts
+++ b/src/js/utils/queryParams.ts
@@ -1,0 +1,21 @@
+export type QueryParamEntry = [string, string];
+export type QueryParamEntries = QueryParamEntry[];
+
+export const queryParamsWithoutKey = (qp: QueryParamEntries, key: string | string[]): QueryParamEntries => {
+  if (typeof key === 'string') {
+    return qp.filter(([k, _]) => k !== key);
+  } else {
+    return qp.filter(([k, _]) => !key.includes(k));
+  }
+};
+
+export const combineQueryParamsWithoutKey = (
+  qp1: QueryParamEntries,
+  qp2: QueryParamEntries,
+  key: string | string[]
+): QueryParamEntries => queryParamsWithoutKey([...qp1, ...qp2], key);
+
+export const buildQueryParamsUrl = (pathName: string, queryParamEntries?: QueryParamEntries): string => {
+  if (!queryParamEntries || !Object.keys(queryParamEntries).length) return pathName;
+  return `${pathName}?${new URLSearchParams(queryParamEntries).toString()}`;
+};

--- a/src/public/locales/en/default_translation_en.json
+++ b/src/public/locales/en/default_translation_en.json
@@ -549,6 +549,7 @@
     },
     "toolbar": {
       "search_placeholder": "Search datasets, keywords, assays…",
+      "sort_label": "Sort",
       "sort": {
         "recently_updated": "Recently updated",
         "newest_created": "Newest created",

--- a/src/public/locales/en/default_translation_en.json
+++ b/src/public/locales/en/default_translation_en.json
@@ -535,7 +535,8 @@
   },
   "catalogue": {
     "rail": {
-      "title": "Filters"
+      "title": "Filters",
+      "close": "Close filters"
     },
     "facets": {
       "projects": "Project",

--- a/src/public/locales/fr/default_translation_fr.json
+++ b/src/public/locales/fr/default_translation_fr.json
@@ -181,6 +181,7 @@
     },
     "toolbar": {
       "search_placeholder": "Rechercher des jeux de données, mots-clés, dosages …",
+      "sort_label": "Trier",
       "sort": {
         "recently_updated": "Récemment mis à jour",
         "newest_created": "Tout récemment créé",

--- a/src/public/locales/fr/default_translation_fr.json
+++ b/src/public/locales/fr/default_translation_fr.json
@@ -167,7 +167,8 @@
   "Back to catalogue": "Retourner au catalogue",
   "catalogue": {
     "rail": {
-      "title": "Filtres"
+      "title": "Filtres",
+      "close": "Fermer les filtres"
     },
     "facets": {
       "projects": "Projet",

--- a/src/styles.css
+++ b/src/styles.css
@@ -605,8 +605,9 @@ body {
 /* END catalogue charts */
 
 /* BEGIN catalogue toolbar */
-.catalogue-search-input { flex-grow: 1; min-width: 200px; border-radius: 6px; }
-.catalogue-sort-select { width: 180px; }
+.catalogue-search-input { flex-grow: 1; flex-shrink: 1; min-width: 70px; border-radius: 6px; }
+.catalogue-sort-select { width: 180px; flex-shrink: 1; min-width: 70px; }
+.catalogue-toolbar-fixed { flex-shrink: 0; }
 .catalogue-count-highlight { color: rgba(0, 0, 0, 0.88); font-weight: 600; }
 .catalogue-filter-tag { border-radius: 13px !important; margin: 0 !important; }
 .catalogue-filter-tag__facet-label { color: var(--text-muted); font-size: 11px; margin-right: 3px; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -411,6 +411,14 @@ body {
   max-height: calc(100vh - var(--header-height) - (2 * var(--content-padding-v)));
 }
 
+.site-sider-shell__header {
+  display: flex;
+  gap: 1rem;
+}
+.site-sider-shell__title {
+  font-size: 1.1rem;
+}
+
 #content-layout {
   position: fixed;
   top: var(--header-height);

--- a/src/styles.css
+++ b/src/styles.css
@@ -761,6 +761,40 @@ body {
   color: var(--cat-chip-count-selected);
 }
 
+.catalogue-rail-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 18;
+  backdrop-filter: blur(10px);
+}
+
+.catalogue-rail--overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 19;
+  width: min(320px, 90vw);
+  max-height: 100vh;
+  border-radius: 0;
+  box-shadow: 3px 0 10px rgba(0, 0, 0, 0.06);
+  transform: translateX(-100%);
+  transition: transform 0.2s ease-out;
+}
+
+.catalogue-rail--overlay.catalogue-rail--open {
+  transform: translateX(0);
+}
+
+.catalogue-rail__close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  color: var(--text-secondary);
+  padding: 2px;
+  line-height: 1;
+}
+
 /* END catalogue rail */
 
 /* BEGIN catalogue card */

--- a/src/styles.css
+++ b/src/styles.css
@@ -598,6 +598,17 @@ body {
 .catalogue-clear-tag { border-radius: 13px !important; margin: 0 !important; cursor: pointer; border-style: dashed; }
 /* END catalogue toolbar */
 
+/* Bigger active-filter-tag variant used on the overview page (between the About section and count cards) */
+.overview-filter-tag {
+  font-size: 14px !important;
+  padding: 4px 10px !important;
+  height: auto !important;
+  line-height: 1.4 !important;
+}
+.overview-filter-tag .catalogue-filter-tag__facet-label {
+  font-size: 12.5px;
+}
+
 /* BEGIN catalogue insights */
 .catalogue-insights {
   background: var(--cat-insights-bg);


### PR DESCRIPTION
- Made the URL the source of truth for catalogue filters (`q/sort/view/facet sets`) - Redux only hydrates from it now, components navigate instead of dispatching filter state directly. Mirrors how Search already works.
- Shared URL query-param plumbing (`utils/queryParams.ts`) between catalogue and search; catalogue facet params switched from comma-joined to repeated-key encoding to match search and fix a latent comma-splitting bug.
- Made the facet rail mobile-friendly : slide-over drawer below lg, toolbar collapses sort to an icon dropdown and hides the grid/list switch to keep search/sort/filters on one row.
- Extracted the URL-sync/action logic into generic hooks (useUrlFacetSync, useUrlFacetActions) and the rail's header+collapsible-sections chrome into a generic FacetSider component, then wired both CatalogueRail and SiteSider through them.
- Deduped a hardcoded facet-label translation map that duplicated key construction already done elsewhere.

Catalogue and search are two independent filter UIs (different Redux slices, different backing data, catalogue is static project/dataset metadata, search is live katsu discovery). This PR doesn't fully merge them, that's not viable yet since search's filters are dynamic/typed (enum/range/date) against katsu fields, while catalogue's are a fixed small set of string facets. As the logic would change significantly when we introduce Dataset's data based filtering, this would make it easier for us to combine both of them.