### PR TITLE
feat: add column picker for discovery match CSV export

### DIFF
--- a/src/js/components/Search/ExportFieldsModal.tsx
+++ b/src/js/components/Search/ExportFieldsModal.tsx
@@ -3,17 +3,19 @@ import { Checkbox, Divider, Flex, Modal, Space, Spin } from 'antd';
 
 import { useTranslationFn } from '@/hooks';
 import { useDiscoveryMatchExportFields } from '@/hooks/useDiscoveryMatchExportFields';
-import type { ResultsDataEntity } from '@/types/entities';
+import type { ExportFormat, ResultsDataEntity } from '@/types/entities';
 
 const ExportFieldsModal = ({
   open,
   entity,
+  format,
   exporting,
   onCancel,
   onExport,
 }: {
   open: boolean;
   entity: ResultsDataEntity;
+  format: ExportFormat;
   exporting: boolean;
   onCancel: () => void;
   onExport: (fields: string[] | undefined) => void;
@@ -51,8 +53,8 @@ const ExportFieldsModal = ({
     <Modal
       open={open}
       onCancel={onCancel}
-      title={t('search.export_csv')}
-      okText={t('search.export_csv')}
+      title={`${t('search.export_data')} (${t(`search.${format}`)})`}
+      okText={t('search.export')}
       onOk={() => onExport(allSelected ? undefined : [...selectedKeys])}
       okButtonProps={{ disabled: fetching || selectedKeys.size === 0, loading: exporting }}
     >

--- a/src/js/components/Search/ExportFieldsModal.tsx
+++ b/src/js/components/Search/ExportFieldsModal.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Checkbox, Divider, Flex, Modal, Space, Spin } from 'antd';
+
+import { useTranslationFn } from '@/hooks';
+import { useDiscoveryMatchExportFields } from '@/hooks/useDiscoveryMatchExportFields';
+import type { ResultsDataEntity } from '@/types/entities';
+
+const ExportFieldsModal = ({
+  open,
+  entity,
+  exporting,
+  onCancel,
+  onExport,
+}: {
+  open: boolean;
+  entity: ResultsDataEntity;
+  exporting: boolean;
+  onCancel: () => void;
+  onExport: (fields: string[] | undefined) => void;
+}) => {
+  const t = useTranslationFn();
+  const { fields, fetching, fetchFields } = useDiscoveryMatchExportFields();
+
+  // null = every field selected (the default, and what "select all" resets to).
+  const [deselectedKeys, setDeselectedKeys] = useState<Set<string> | null>(null);
+
+  useEffect(() => {
+    if (open) fetchFields(entity);
+  }, [open, entity, fetchFields]);
+
+  const selectedKeys = useMemo(
+    () => new Set((fields ?? []).map((f) => f.key).filter((k) => !deselectedKeys?.has(k))),
+    [fields, deselectedKeys]
+  );
+  const allSelected = deselectedKeys === null || deselectedKeys.size === 0;
+
+  const toggleAll = (checked: boolean) => setDeselectedKeys(checked ? null : new Set(fields?.map((f) => f.key)));
+
+  const toggleKey = (key: string, checked: boolean) =>
+    setDeselectedKeys((dk) => {
+      const next = new Set(dk ?? []);
+      if (checked) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+
+  return (
+    <Modal
+      open={open}
+      onCancel={onCancel}
+      title={t('search.export_csv')}
+      okText={t('search.export_csv')}
+      onOk={() => onExport(allSelected ? undefined : [...selectedKeys])}
+      okButtonProps={{ disabled: fetching || selectedKeys.size === 0, loading: exporting }}
+    >
+      {fetching || !fields ? (
+        <Spin />
+      ) : (
+        <>
+          <Flex justify="space-between" align="center">
+            <Checkbox
+              checked={allSelected}
+              indeterminate={!allSelected && selectedKeys.size > 0}
+              onChange={(e) => toggleAll(e.target.checked)}
+            >
+              {t('search.select_all_fields')}
+            </Checkbox>
+            <span className="text-secondary">
+              {selectedKeys.size} / {fields.length}
+            </span>
+          </Flex>
+          <Divider className="my-3" />
+          <Space direction="vertical">
+            {fields.map(({ key, label }) => (
+              <Checkbox key={key} checked={selectedKeys.has(key)} onChange={(e) => toggleKey(key, e.target.checked)}>
+                {label}
+              </Checkbox>
+            ))}
+          </Space>
+        </>
+      )}
+    </Modal>
+  );
+};
+
+export default ExportFieldsModal;

--- a/src/js/components/Search/SearchResultsTablePage.tsx
+++ b/src/js/components/Search/SearchResultsTablePage.tsx
@@ -1,7 +1,18 @@
 import { type ReactNode, useCallback, useMemo, useState } from 'react';
 
-import { Button, Checkbox, Col, Flex, Modal, Space, type TablePaginationConfig, Tooltip, Typography } from 'antd';
-import { ExportOutlined, LeftOutlined, TableOutlined } from '@ant-design/icons';
+import {
+  Button,
+  Checkbox,
+  Col,
+  Dropdown,
+  Flex,
+  Modal,
+  Space,
+  type TablePaginationConfig,
+  Tooltip,
+  Typography,
+} from 'antd';
+import { DownloadOutlined, DownOutlined, LeftOutlined, TableOutlined } from '@ant-design/icons';
 
 import { T_PLURAL_COUNT, T_SINGULAR_COUNT } from '@/constants/i18n';
 import { MIN_PAGE_SIZE, PAGE_SIZE_OPTIONS } from '@/constants/pagination';
@@ -11,7 +22,7 @@ import { TABLE_PAGE_QUERY_PARAM, TABLE_PAGE_SIZE_QUERY_PARAM } from '@/features/
 import { useTranslationFn } from '@/hooks';
 import { useSmallScreen } from '@/hooks/useResponsiveContext';
 import { useScopeDownloadData } from '@/hooks/censorship';
-import { useDownloadAllMatchesCSV } from '@/hooks/useDownloadAllMatchesCSV';
+import { useDownloadAllMatches } from '@/hooks/useDownloadAllMatches';
 import { useSearchQuery, useSearchQueryParams } from '@/features/search/hooks';
 import { useNavigateToSameScopeUrl } from '@/hooks/navigation';
 import { useMetadata, useSelectedScope } from '@/features/metadata/hooks';
@@ -28,6 +39,7 @@ import type {
   DiscoveryMatchPhenopacket,
   ViewableDiscoveryMatchObject,
 } from '@/features/search/types';
+import type { ExportFormat } from '@/types/entities';
 import { BentoRoute } from '@/types/routes';
 
 import { scopeSelectionEqual } from '@/features/metadata/utils';
@@ -308,7 +320,7 @@ const SearchResultsTable = <T extends ViewableDiscoveryMatchObject>({
 
   const { resultCountsOrBools, pageSize, matchData } = useSearchQuery();
   const { fetchingPermission: fetchingCanDownload, hasPermission: canDownload } = useScopeDownloadData();
-  const downloadAllMatchesCSV = useDownloadAllMatchesCSV();
+  const downloadAllMatches = useDownloadAllMatches();
   const isSmallScreen = useSmallScreen();
 
   const allQueryParams = useSearchQueryParams();
@@ -320,6 +332,7 @@ const SearchResultsTable = <T extends ViewableDiscoveryMatchObject>({
   const [exporting, setExporting] = useState<boolean>(false);
   const [columnModalOpen, setColumnModalOpen] = useState<boolean>(false);
   const [exportModalOpen, setExportModalOpen] = useState<boolean>(false);
+  const [exportFormat, setExportFormat] = useState<ExportFormat>('csv');
 
   // We translate an "individual" entity to "phenopacket" because TODO.
   // TODO: maybe we can make Katsu good enough that we can just simply return individuals rather than phenopackets
@@ -424,16 +437,29 @@ const SearchResultsTable = <T extends ViewableDiscoveryMatchObject>({
   const onExport = useCallback(
     (fields: string[] | undefined) => {
       setExporting(true);
-      const filename = `${t(`entities.${entity}_other`)}.csv`;
-      downloadAllMatchesCSV(rdEntity, filename, fields)
+      const filename = `${t(`entities.${entity}_other`)}.${exportFormat}`;
+      downloadAllMatches(rdEntity, exportFormat, filename, fields)
         .then(() => setExportModalOpen(false))
         .finally(() => setExporting(false));
     },
-    [t, entity, downloadAllMatchesCSV, rdEntity]
+    [t, entity, downloadAllMatches, rdEntity, exportFormat]
   );
 
   const openColumnModal = useCallback(() => setColumnModalOpen(true), []);
-  const openExportModal = useCallback(() => setExportModalOpen(true), []);
+  const openExportModal = useCallback((format: ExportFormat) => {
+    setExportFormat(format);
+    setExportModalOpen(true);
+  }, []);
+
+  const exportMenuItems = useMemo(
+    () =>
+      (['csv', 'xlsx'] as ExportFormat[]).map((format) => ({
+        key: format,
+        label: t(`search.${format}`),
+        onClick: () => openExportModal(format),
+      })),
+    [t, openExportModal]
+  );
 
   if (!shown) return null;
 
@@ -468,14 +494,15 @@ const SearchResultsTable = <T extends ViewableDiscoveryMatchObject>({
               <Button icon={<TableOutlined />} onClick={openColumnModal} />
             </Tooltip>
             {fetchingCanDownload || canDownload ? (
-              <Button
-                icon={<ExportOutlined />}
-                loading={fetchingCanDownload}
-                onClick={openExportModal}
-                disabled={fetchingCanDownload || !totalMatches}
-              >
-                {isSmallScreen ? t('search.csv') : t('search.export_csv')}
-              </Button>
+              <Dropdown menu={{ items: exportMenuItems }} disabled={fetchingCanDownload || !totalMatches}>
+                <Button
+                  icon={<DownloadOutlined />}
+                  loading={fetchingCanDownload}
+                  disabled={fetchingCanDownload || !totalMatches}
+                >
+                  {t('search.export')} <DownOutlined />
+                </Button>
+              </Dropdown>
             ) : null}
           </Space>
         </Flex>
@@ -518,6 +545,7 @@ const SearchResultsTable = <T extends ViewableDiscoveryMatchObject>({
       <ExportFieldsModal
         open={exportModalOpen}
         entity={rdEntity}
+        format={exportFormat}
         exporting={exporting}
         onCancel={() => setExportModalOpen(false)}
         onExport={onExport}

--- a/src/js/components/Search/SearchResultsTablePage.tsx
+++ b/src/js/components/Search/SearchResultsTablePage.tsx
@@ -39,6 +39,7 @@ import {
 import { setEquals } from '@/utils/sets';
 
 import DatasetProvenanceModal from '@/components/Provenance/DatasetProvenanceModal';
+import ExportFieldsModal from './ExportFieldsModal';
 import ProjectTitle from '@Util/ProjectTitle';
 import DatasetTitle from '@Util/DatasetTitle';
 import ExperimentReferences from '@Util/ClinPhen/ExperimentReferences';
@@ -318,6 +319,7 @@ const SearchResultsTable = <T extends ViewableDiscoveryMatchObject>({
 
   const [exporting, setExporting] = useState<boolean>(false);
   const [columnModalOpen, setColumnModalOpen] = useState<boolean>(false);
+  const [exportModalOpen, setExportModalOpen] = useState<boolean>(false);
 
   // We translate an "individual" entity to "phenopacket" because TODO.
   // TODO: maybe we can make Katsu good enough that we can just simply return individuals rather than phenopackets
@@ -419,13 +421,19 @@ const SearchResultsTable = <T extends ViewableDiscoveryMatchObject>({
     [page, pageSize, totalMatches, isSmallScreen, navigateToSameScopeUrl, allQueryParams]
   );
 
-  const onExport = useCallback(() => {
-    setExporting(true);
-    const filename = `${t(`entities.${entity}_other`)}.csv`;
-    downloadAllMatchesCSV(rdEntity, filename).finally(() => setExporting(false));
-  }, [t, entity, downloadAllMatchesCSV, rdEntity]);
+  const onExport = useCallback(
+    (fields: string[] | undefined) => {
+      setExporting(true);
+      const filename = `${t(`entities.${entity}_other`)}.csv`;
+      downloadAllMatchesCSV(rdEntity, filename, fields)
+        .then(() => setExportModalOpen(false))
+        .finally(() => setExporting(false));
+    },
+    [t, entity, downloadAllMatchesCSV, rdEntity]
+  );
 
   const openColumnModal = useCallback(() => setColumnModalOpen(true), []);
+  const openExportModal = useCallback(() => setExportModalOpen(true), []);
 
   if (!shown) return null;
 
@@ -462,8 +470,8 @@ const SearchResultsTable = <T extends ViewableDiscoveryMatchObject>({
             {fetchingCanDownload || canDownload ? (
               <Button
                 icon={<ExportOutlined />}
-                loading={fetchingCanDownload || exporting}
-                onClick={onExport}
+                loading={fetchingCanDownload}
+                onClick={openExportModal}
                 disabled={fetchingCanDownload || !totalMatches}
               >
                 {isSmallScreen ? t('search.csv') : t('search.export_csv')}
@@ -507,6 +515,13 @@ const SearchResultsTable = <T extends ViewableDiscoveryMatchObject>({
             ))}
         </Space>
       </Modal>
+      <ExportFieldsModal
+        open={exportModalOpen}
+        entity={rdEntity}
+        exporting={exporting}
+        onCancel={() => setExportModalOpen(false)}
+        onExport={onExport}
+      />
     </>
   );
 };

--- a/src/js/constants/configConstants.ts
+++ b/src/js/constants/configConstants.ts
@@ -9,6 +9,7 @@ export const katsuDiscoveryRulesUrl = `${katsuBaseUrl}/api/discovery_rules`;
 export const katsuDiscoverySearchFieldsUrl = `${katsuBaseUrl}/api/discovery_search_fields`;
 export const katsuDiscoveryUrl = `${katsuBaseUrl}/api/discovery`;
 export const katsuDiscoveryMatchesUrl = `${katsuBaseUrl}/api/discovery_matches`;
+export const katsuDiscoveryMatchesExportFieldsUrl = `${katsuBaseUrl}/api/discovery_matches_export_fields`;
 export const katsuDiscoveryUIHintsUrl = `${katsuBaseUrl}/api/discovery_ui_hints`;
 
 // Katsu entity API (Django Rest Framework) base URLs

--- a/src/js/hooks/useDiscoveryMatchExportFields.ts
+++ b/src/js/hooks/useDiscoveryMatchExportFields.ts
@@ -1,0 +1,42 @@
+import { useCallback, useState } from 'react';
+import axios from 'axios';
+import { useAppSelector } from '@/hooks';
+import { useSelectedScope } from '@/features/metadata/hooks';
+import { scopedAuthorizedRequestConfigFromParts } from '@/utils/requests';
+import { katsuDiscoveryMatchesExportFieldsUrl } from '@/constants/configConstants';
+import type { ResultsDataEntity, ExportField } from '@/types/entities';
+
+// Fields available per entity rarely change within a session, so cache per-entity once fetched.
+const fieldsCache = new Map<ResultsDataEntity, ExportField[]>();
+
+export const useDiscoveryMatchExportFields = () => {
+  const auth = useAppSelector((state) => state.auth);
+  const selectedScope = useSelectedScope();
+
+  const [fields, setFields] = useState<ExportField[] | null>(null);
+  const [fetching, setFetching] = useState<boolean>(false);
+
+  const fetchFields = useCallback(
+    async (entity: ResultsDataEntity) => {
+      const cached = fieldsCache.get(entity);
+      if (cached) {
+        setFields(cached);
+        return;
+      }
+
+      setFetching(true);
+      setFields(null);
+      try {
+        const config = scopedAuthorizedRequestConfigFromParts(auth, selectedScope, [['_entity', entity]]);
+        const res = await axios.get<ExportField[]>(katsuDiscoveryMatchesExportFieldsUrl, config);
+        fieldsCache.set(entity, res.data);
+        setFields(res.data);
+      } finally {
+        setFetching(false);
+      }
+    },
+    [auth, selectedScope]
+  );
+
+  return { fields, fetching, fetchFields };
+};

--- a/src/js/hooks/useDownloadAllMatches.ts
+++ b/src/js/hooks/useDownloadAllMatches.ts
@@ -2,24 +2,24 @@ import { useCallback } from 'react';
 import { useAppSelector } from '@/hooks';
 import { useSelectedScope } from '@/features/metadata/hooks';
 import { useSearchQuery } from '@/features/search/hooks';
-import type { ResultsDataEntity } from '@/types/entities';
+import type { ExportFormat, ResultsDataEntity } from '@/types/entities';
 import { scopedAuthorizedRequestConfigFromParts } from '@/utils/requests';
 import { searchQueryParamsFromState } from '@/features/search/utils';
 import axios from 'axios';
 import { katsuDiscoveryMatchesUrl } from '@/constants/configConstants';
 import FileSaver from 'file-saver';
 
-export const useDownloadAllMatchesCSV = () => {
+export const useDownloadAllMatches = () => {
   const auth = useAppSelector((state) => state.auth);
   const query = useSearchQuery();
   const selectedScope = useSelectedScope();
 
   return useCallback(
-    async (entity: ResultsDataEntity, filename: string, fields?: string[]) => {
+    async (entity: ResultsDataEntity, format: ExportFormat, filename: string, fields?: string[]) => {
       const config = scopedAuthorizedRequestConfigFromParts(auth, selectedScope, [
         ...searchQueryParamsFromState(query),
         ['_entity', entity],
-        ['_format', 'csv'],
+        ['_format', format],
         ['_page_size', '0'], // 0 means export all results
         ...(fields && fields.length > 0 ? [['_fields', fields.join(',')] as [string, string]] : []),
       ]);

--- a/src/js/hooks/useDownloadAllMatchesCSV.ts
+++ b/src/js/hooks/useDownloadAllMatchesCSV.ts
@@ -15,12 +15,13 @@ export const useDownloadAllMatchesCSV = () => {
   const selectedScope = useSelectedScope();
 
   return useCallback(
-    async (entity: ResultsDataEntity, filename: string) => {
+    async (entity: ResultsDataEntity, filename: string, fields?: string[]) => {
       const config = scopedAuthorizedRequestConfigFromParts(auth, selectedScope, [
         ...searchQueryParamsFromState(query),
         ['_entity', entity],
         ['_format', 'csv'],
         ['_page_size', '0'], // 0 means export all results
+        ...(fields && fields.length > 0 ? [['_fields', fields.join(',')] as [string, string]] : []),
       ]);
 
       const res = await axios.get(katsuDiscoveryMatchesUrl, {

--- a/src/js/types/entities.ts
+++ b/src/js/types/entities.ts
@@ -4,6 +4,8 @@ export type BentoCountEntity = Exclude<BentoKatsuEntity, 'phenopacket'>;
 export type ResultsDataEntity = Exclude<BentoKatsuEntity, 'individual'>;
 export type BentoUICountEntity = BentoCountEntity | 'dataset'; // extended definition for other UI count elements
 
+export type ExportField = { key: string; label: string };
+
 // If boolean, it means we have data above the threshold but don't have permissions to view the exact count.
 export type KatsuEntityCountsOrBooleans = Record<BentoKatsuEntity, number | boolean>;
 export type BentoCountEntityCountsOrBooleans = Record<BentoCountEntity, number | boolean>;

--- a/src/js/types/entities.ts
+++ b/src/js/types/entities.ts
@@ -6,6 +6,8 @@ export type BentoUICountEntity = BentoCountEntity | 'dataset'; // extended defin
 
 export type ExportField = { key: string; label: string };
 
+export type ExportFormat = 'csv' | 'xlsx';
+
 // If boolean, it means we have data above the threshold but don't have permissions to view the exact count.
 export type KatsuEntityCountsOrBooleans = Record<BentoKatsuEntity, number | boolean>;
 export type BentoCountEntityCountsOrBooleans = Record<BentoCountEntity, number | boolean>;

--- a/src/public/locales/en/default_translation_en.json
+++ b/src/public/locales/en/default_translation_en.json
@@ -64,9 +64,11 @@
     "showing_entities": "Showing {{entity, lowercase}} {{start}}-{{end}} of {{total}}",
     "showing_entities_short": "{{start}}-{{end}} / {{total}}",
     "manage_columns": "Manage Columns",
-    "export_csv": "Export as CSV",
+    "export": "Export",
+    "export_data": "Export Data",
     "select_all_fields": "Select all",
     "csv": "CSV",
+    "xlsx": "XLSX",
     "fts": {
       "plain": "Word",
       "plain_help": "Retrieves records which exactly match words in the query (case-insensitive).",

--- a/src/public/locales/en/default_translation_en.json
+++ b/src/public/locales/en/default_translation_en.json
@@ -65,6 +65,7 @@
     "showing_entities_short": "{{start}}-{{end}} / {{total}}",
     "manage_columns": "Manage Columns",
     "export_csv": "Export as CSV",
+    "select_all_fields": "Select all",
     "csv": "CSV",
     "fts": {
       "plain": "Word",

--- a/src/public/locales/fr/default_translation_fr.json
+++ b/src/public/locales/fr/default_translation_fr.json
@@ -67,6 +67,7 @@
     "showing_entities_short": "{{start}}-{{end}} / {{total}}",
     "manage_columns": "Gérer les colonnes",
     "export_csv": "Exporter en CSV",
+    "select_all_fields": "Tout sélectionner",
     "csv": "CSV",
     "fts": {
       "plain": "Mot",

--- a/src/public/locales/fr/default_translation_fr.json
+++ b/src/public/locales/fr/default_translation_fr.json
@@ -66,9 +66,11 @@
     "showing_entities": "Affichage des {{entity, lowercase}} {{start}}-{{end}} sur {{total}}",
     "showing_entities_short": "{{start}}-{{end}} / {{total}}",
     "manage_columns": "Gérer les colonnes",
-    "export_csv": "Exporter en CSV",
+    "export": "Exporter",
+    "export_data": "Exporter les données",
     "select_all_fields": "Tout sélectionner",
     "csv": "CSV",
+    "xlsx": "XLSX",
     "fts": {
       "plain": "Mot",
       "plain_help": "Récupère les enregistrements qui correspondent exactement aux mots de la requête (sans distinction de casse).",

--- a/src/styles.css
+++ b/src/styles.css
@@ -118,6 +118,7 @@ body {
 .mb-3 { margin-bottom: 12px; }
 .mt-2 { margin-top: 8px; }
 .mt-3 { margin-top: 12px; }
+.my-3 { margin-top: 12px; margin-bottom: 12px; }
 .ml-2 { margin-left: 8px; }
 .pt-2 { padding-top: 8px; }
 .pt-5 { padding-top: 20px; }


### PR DESCRIPTION
Requires: https://github.com/bento-platform/katsu/pull/714
## Summary
- Add column picker for CSV export of search results, backed by new `discovery_matches_export_fields` endpoint
- New `ExportFieldsModal` lets users select a subset of columns before exporting; defaults to all fields (unchanged prior behavior)
- `useDownloadAllMatchesCSV` now accepts optional `fields` and sends `_fields` param only when a subset is chosen